### PR TITLE
Allow adding pathes to ClassPath during tests execution.

### DIFF
--- a/findbugs-test-util/src/test/java/com/h3xstream/findbugs/test/BaseDetectorTest.java
+++ b/findbugs-test-util/src/test/java/com/h3xstream/findbugs/test/BaseDetectorTest.java
@@ -50,10 +50,13 @@ public class BaseDetectorTest {
         findBugsLauncher.analyze(classFiles, bugReporter);
     }
 
+    public void analyze(String[] classFiles, String[] classpath, BugReporter bugReporter) throws Exception {
+        findBugsLauncher.analyze(classFiles, classpath, bugReporter);
+    }
+
     public BugInstanceMatcherBuilder bugDefinition() {
         return new BugInstanceMatcherBuilder();
     }
-
 
     public static BugInstance anyBugs() {
         return Matchers.<BugInstance>any();

--- a/findbugs-test-util/src/test/java/com/h3xstream/findbugs/test/service/FindBugsLauncher.java
+++ b/findbugs-test-util/src/test/java/com/h3xstream/findbugs/test/service/FindBugsLauncher.java
@@ -63,14 +63,35 @@ public class FindBugsLauncher {
      * @throws URISyntaxException 
      *
      */
-    public void analyze(String[] classFiles, BugReporter bugReporter) throws IOException, InterruptedException,
-            PluginException, NoSuchFieldException, IllegalAccessException, URISyntaxException {
+	public void analyze(String[] classFiles, BugReporter bugReporter) throws IOException, InterruptedException,
+	        PluginException, NoSuchFieldException, IllegalAccessException, URISyntaxException {
+		analyze(classFiles, new String[] {}, bugReporter);
+	}
 
+    /**
+     * Launch an analysis on the given source files.
+     *
+     * @param classFiles
+     * @param classpath
+     * @param bugReporter
+     * @throws java.io.IOException
+     * @throws InterruptedException
+     * @throws edu.umd.cs.findbugs.PluginException
+     * @throws URISyntaxException
+     *
+     */
+    public void analyze(String[] classFiles, String[] classpathes, BugReporter bugReporter) throws IOException, InterruptedException,
+    		PluginException, NoSuchFieldException, IllegalAccessException, URISyntaxException {
         Project project = new Project();
         project.setProjectName("automate-test-project");
         for (String file : classFiles) {
             project.addFile(file);
         }
+
+        // Add classpath list to project's auxclasspath
+        for (String classpath : classpathes) {
+        	project.addAuxClasspathEntry(classpath);
+        };
 
         if (loadedPlugin == null) {
             //Initialize the plugin base on the findbugs.xml
@@ -85,6 +106,7 @@ public class FindBugsLauncher {
 
             loadedPlugin = Plugin.loadCustomPlugin(f.toURI().toURL(), project);
         }
+
         //FindBugs engine
         FindBugs2 engine = new FindBugs2();
         engine.setNoClassOk(true);


### PR DESCRIPTION
Overrides `BaseDetectorTest.Analyze(...)` to allow adding pathes to ClassPath during tests execution.