### PR TITLE
Allow analyze to set classpath entries

### DIFF
--- a/findbugs-test-util/src/test/java/com/h3xstream/findbugs/test/BaseDetectorTest.java
+++ b/findbugs-test-util/src/test/java/com/h3xstream/findbugs/test/BaseDetectorTest.java
@@ -45,15 +45,22 @@ public class BaseDetectorTest {
     public String getJspFilePath(String path) {
         return classFileLocator.getJspFilePath(path);
     }
+    
+    public String getJarFilePath(String path) {
+        return classFileLocator.getJarFilePath(path);
+    }
 
     public void analyze(String[] classFiles, BugReporter bugReporter) throws Exception {
         findBugsLauncher.analyze(classFiles, bugReporter);
     }
 
+    public void analyze(String[] classFiles, String[] classPaths, BugReporter bugReporter) throws Exception {
+        findBugsLauncher.analyze(classFiles, classPaths, bugReporter);
+    }
+
     public BugInstanceMatcherBuilder bugDefinition() {
         return new BugInstanceMatcherBuilder();
     }
-
 
     public static BugInstance anyBugs() {
         return Matchers.<BugInstance>any();

--- a/findbugs-test-util/src/test/java/com/h3xstream/findbugs/test/service/ClassFileLocator.java
+++ b/findbugs-test-util/src/test/java/com/h3xstream/findbugs/test/service/ClassFileLocator.java
@@ -44,6 +44,13 @@ public class ClassFileLocator {
         assertNotNull(url, "No jsp file found for the path = " + path);
         return getFilenameFromUrl(url);
     }
+    
+    public String getJarFilePath(String path) {
+        ClassLoader cl = getClass().getClassLoader();
+        URL url = cl.getResource(path);
+        assertNotNull(url, "No jar found for the path = " + path);
+        return getFilenameFromUrl(url);
+    }
 
     private String getFilenameFromUrl(URL url) {
         String filename = url.toString();

--- a/findbugs-test-util/src/test/java/com/h3xstream/findbugs/test/service/FindBugsLauncher.java
+++ b/findbugs-test-util/src/test/java/com/h3xstream/findbugs/test/service/FindBugsLauncher.java
@@ -63,13 +63,34 @@ public class FindBugsLauncher {
      * @throws URISyntaxException 
      *
      */
-    public void analyze(String[] classFiles, BugReporter bugReporter) throws IOException, InterruptedException,
-            PluginException, NoSuchFieldException, IllegalAccessException, URISyntaxException {
+	public void analyze(String[] classFiles, BugReporter bugReporter) throws IOException, InterruptedException,
+	        PluginException, NoSuchFieldException, IllegalAccessException, URISyntaxException {
+		analyze(classFiles, new String[] {}, bugReporter);
+	}
 
+    /**
+     * Launch an analysis on the given source files.
+     *
+     * @param classFiles
+     * @param classPaths
+     * @param bugReporter
+     * @throws java.io.IOException
+     * @throws InterruptedException
+     * @throws edu.umd.cs.findbugs.PluginException
+     * @throws URISyntaxException
+     *
+     */
+    public void analyze(String[] classFiles, String[] classPaths, BugReporter bugReporter) throws IOException, InterruptedException,
+    		PluginException, NoSuchFieldException, IllegalAccessException, URISyntaxException {
         Project project = new Project();
         project.setProjectName("automate-test-project");
         for (String file : classFiles) {
             project.addFile(file);
+        }
+
+        // Add classpath list to project's auxclasspath
+        for (String classpath : classPaths) {
+        	project.addAuxClasspathEntry(classpath);
         }
 
         if (loadedPlugin == null) {
@@ -85,6 +106,7 @@ public class FindBugsLauncher {
 
             loadedPlugin = Plugin.loadCustomPlugin(f.toURI().toURL(), project);
         }
+
         //FindBugs engine
         FindBugs2 engine = new FindBugs2();
         engine.setNoClassOk(true);


### PR DESCRIPTION
 - This allows to test scenarios where bugs occur due to interactions with
    code from third-party libraries.
 - Overrides BaseDetector.analyze() and FindbugsLauncher.analyze() to allow
    adding paths to auxClassPath during tests execution.
 - Add utility methods to get paths to jars in src/test/resources.