### PR TITLE
Separated hard coded password and key reporting

### DIFF
--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -47,7 +47,7 @@
     <Detector class="com.h3xstream.findsecbugs.crypto.UnencryptedSocketDetector" reports="UNENCRYPTED_SOCKET"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.DesUsageDetector" reports="DES_USAGE"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.RsaNoPaddingDetector" reports="RSA_NO_PADDING"/>
-    <Detector class="com.h3xstream.findsecbugs.password.ConstantPasswordDetector" reports="HARD_CODE_PASSWORD"/>
+    <Detector class="com.h3xstream.findsecbugs.password.ConstantPasswordDetector" reports="HARD_CODE_PASSWORD,HARD_CODE_KEY"/>
     <Detector class="com.h3xstream.findsecbugs.password.GoogleApiKeyDetector" reports="HARD_CODE_PASSWORD"/>
     <Detector class="com.h3xstream.findsecbugs.password.JndiCredentialsDetector" reports="HARD_CODE_PASSWORD"/>
     <Detector class="com.h3xstream.findsecbugs.StrutsValidatorFormDetector" reports="STRUTS_FORM_VALIDATION"/>
@@ -109,7 +109,8 @@
     <BugPattern type="UNENCRYPTED_SOCKET" abbrev="SECUS" category="SECURITY"/>
     <BugPattern type="DES_USAGE" abbrev="SECDU" category="SECURITY"/>
     <BugPattern type="RSA_NO_PADDING" abbrev="SECRNP" category="SECURITY"/>
-    <BugPattern type="HARD_CODE_PASSWORD" abbrev="SECHCP" category="SECURITY"/>
+    <BugPattern type="HARD_CODE_PASSWORD" abbrev="SECHCP" category="SECURITY" cweid="259"/>
+    <BugPattern type="HARD_CODE_KEY" abbrev="SECHCK" category="SECURITY" cweid="321"/>
     <BugPattern type="STRUTS_FORM_VALIDATION" abbrev="SECSFV" category="SECURITY"/>
     <BugPattern type="XSS_REQUEST_WRAPPER" abbrev="SECXRW" category="SECURITY"/>
     <BugPattern type="RSA_KEY_SIZE" abbrev="SECRKS" category="SECURITY"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -1607,7 +1607,7 @@ The code should be replaced with:<br/>
 
     <!-- Hard coded passwords and keys in various method calls -->
     <Detector class="com.h3xstream.findsecbugs.password.ConstantPasswordDetector">
-        <Details>Identify hardcoded password in KeyStore initialization</Details>
+        <Details>Identify hardcoded passwords and keys</Details>
     </Detector>
 
     <!-- Hard coded Google API key -->
@@ -1628,6 +1628,7 @@ The code should be replaced with:<br/>
 <p>
 Passwords should not be kept in the source code. The source code can be widely shared in an enterprise environment, and is
 certainly shared in open source. To be managed safely, passwords and secret keys should be stored in separate configuration files or keystores.
+(Hard coded keys are reported separately by <i>Hard Coded Key</i> pattern)
 </p>
 <p>
 <p><b>Vulnerable Code:</b><br/>
@@ -1640,13 +1641,41 @@ props.put(Context.SECURITY_CREDENTIALS, "p@ssw0rd");</pre>
 <br/>
 <p>
 <b>References</b><br/>
-<a href="http://cwe.mitre.org/data/definitions/321.html">CWE-321: Use of Hard-coded Cryptographic Key</a><br/>
 <a href="http://cwe.mitre.org/data/definitions/259.html">CWE-259: Use of Hard-coded Password</a>
 </p>
 ]]>
         </Details>
     </BugPattern>
     <BugCode abbrev="SECHCP">Hard Coded Password</BugCode>
+
+<BugPattern type="HARD_CODE_KEY">
+        <ShortDescription>Hard Coded Key</ShortDescription>
+        <LongDescription>Hard coded cryptographic key found</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+Cryptographic keys should not be kept in the source code. The source code can be widely shared in an enterprise environment, and is
+certainly shared in open source. To be managed safely, passwords and secret keys should be stored in separate configuration files or keystores.
+(Hard coded passwords are reported separately by <i>Hard Coded Password</i> pattern)
+</p>
+<p>
+<p><b>Vulnerable Code:</b><br/>
+
+<pre>byte[] key = {1, 2, 3, 4, 5, 6, 7, 8};
+SecretKeySpec spec = new SecretKeySpec(key, "AES");
+Cipher aes = Cipher.getInstance("AES");
+aes.init(Cipher.ENCRYPT_MODE, spec);
+return aesCipher.doFinal(secretData);</pre> 
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="http://cwe.mitre.org/data/definitions/321.html">CWE-321: Use of Hard-coded Cryptographic Key</a><br/>
+</p>
+]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECHCK">Hard Coded Key</BugCode>
 
 
     <!-- Struts Form Validation -->

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/password/ConstantPasswordDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/password/ConstantPasswordDetectorTest.java
@@ -37,15 +37,26 @@ public class ConstantPasswordDetectorTest extends BaseDetectorTest {
         EasyBugReporter reporter = spy(new EasyBugReporter());
         analyze(files, reporter);
 
-        List<Integer> lines = Arrays.asList(
-                44, 52, 57, 62, 67, 72, 80, 86, 87, 88, 89, 91, 92, 93, 94, 100,
-                101, 102, 104, 105, 106, 107, 108, 109, 110, 116, 121, 123, 129,
-                130, 131, 133, 134, 135, 136, 137, 138, 144, 150, 159, 171
+        List<Integer> linesPasswords = Arrays.asList(
+                44, 52, 57, 62, 67, 72, 80, 86, 87, 88, 89, 91, 92, 93, 94,
+                121, 123, 159, 171
         );
-        for (Integer line : lines) {
+        List<Integer> linesKeys = Arrays.asList(
+                100, 101, 102, 104, 105, 106, 107, 108, 109, 110, 116, 129,
+                130, 131, 133, 134, 135, 136, 137, 138, 144, 150
+        );
+        for (Integer line : linesPasswords) {
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("HARD_CODE_PASSWORD")
+                            .inClass("ConstantPasswords").atLine(line)
+                            .build()
+            );
+        }
+        for (Integer line : linesKeys) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("HARD_CODE_KEY")
                             .inClass("ConstantPasswords").atLine(line)
                             .build()
             );
@@ -58,7 +69,10 @@ public class ConstantPasswordDetectorTest extends BaseDetectorTest {
                         .build()
         );
         
-        verify(reporter, times(lines.size() + 2)).doReportBug(
+        // +1 for OAuth and +1 for hard coded public key field
+        verify(reporter, times(linesPasswords.size() + 1)).doReportBug(
                 bugDefinition().bugType("HARD_CODE_PASSWORD").build());
+        verify(reporter, times(linesKeys.size() + 1)).doReportBug(
+                bugDefinition().bugType("HARD_CODE_KEY").build());
     }
 }


### PR DESCRIPTION
I have created a separated bug pattern for hard coded cryptographic keys - ConstantPasswordDetector now reports hard coded passwords for String and char array types and hard coded keys for the other types. I think this is appropriate since both weaknesses have different CWE ID and are equally important.