### PR TITLE
Improved taint analysis (several bugs fixed, refactoring)

### DIFF
--- a/plugin-deps/src/main/java/javax/servlet/http/Cookie.java
+++ b/plugin-deps/src/main/java/javax/servlet/http/Cookie.java
@@ -2,22 +2,83 @@ package javax.servlet.http;
 
 public class Cookie {
 
+    private String name;
+    private String value;
+    private String path;
+    private int maxAge;
+    private String domain;
+    private int version;
+    private boolean secure;
+    private boolean httpOnly;
+
     public Cookie(String name, String value) {
     }
 
     public String getName() {
-        return "";
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public String getValue() {
-        return "";
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
     }
 
     public String getPath() {
-        return "";
+        return path;
     }
 
-    public void setMaxAge(int i) {
+    public void setPath(String path) {
+        this.path = path;
+    }
 
+    public int getMaxAge() {
+        return maxAge;
+    }
+
+    public void setMaxAge(int maxAge) {
+        this.maxAge = maxAge;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public boolean getSecure() {
+        return secure;
+    }
+
+    public void setSecure(boolean secure) {
+        this.secure = secure;
+    }
+
+    public boolean isSecure() {
+        return secure;
+    }
+
+    public boolean isHttpOnly() {
+        return httpOnly;
+    }
+
+    public void setHttpOnly(boolean httpOnly) {
+        this.httpOnly = httpOnly;
     }
 }

--- a/plugin-deps/src/main/java/javax/servlet/http/HttpServletResponse.java
+++ b/plugin-deps/src/main/java/javax/servlet/http/HttpServletResponse.java
@@ -1,6 +1,7 @@
 package javax.servlet.http;
 
 import javax.servlet.ServletResponse;
+import java.io.IOException;
 
 public interface HttpServletResponse extends ServletResponse {
 
@@ -8,5 +9,5 @@ public interface HttpServletResponse extends ServletResponse {
 
     void addHeader(String header, String value);
 
-    void sendRedirect(String url);
+    void sendRedirect(String url) throws IOException;
 }

--- a/plugin-deps/src/main/java/org/springframework/jdbc/core/JdbcOperations.java
+++ b/plugin-deps/src/main/java/org/springframework/jdbc/core/JdbcOperations.java
@@ -156,4 +156,18 @@ public interface JdbcOperations {
     Map<String, Object> call(CallableStatementCreator csc, List<SqlParameter> declaredParameters)
             throws DataAccessException;
 
+
+
+    //Spring 3.2.1
+    //http://docs.spring.io/spring-framework/docs/2.0.x/api/org/springframework/jdbc/core/JdbcTemplate.html
+
+    int queryForInt(String sql);
+    int queryForInt(String sql, Object[] args);
+    int queryForInt(String sql, Object[] args, int[] argTypes);
+
+
+    long queryForLong(String sql);
+    long queryForLong(String sql, Object[] args);
+    long queryForLong(String sql, Object[] args, int[] argTypes);
+
 }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/common/ByteCode.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/common/ByteCode.java
@@ -59,7 +59,7 @@ public class ByteCode {
             System.out.println(ins.getClass().getSimpleName() +" target => "+i.getTarget().toString()+ "");
         } else if (ins instanceof ICONST) {
             ICONST i = (ICONST) ins;
-            System.out.println(ins.getClass().getSimpleName() +" "+i.getValue());
+            System.out.println(ins.getClass().getSimpleName() +" "+i.getValue()+" ("+i.getType(cpg)+")");
         } else if (ins instanceof GOTO) {
             GOTO i = (GOTO) ins;
             System.out.println(ins.getClass().getSimpleName() +" target => "+i.getTarget().toString());
@@ -80,11 +80,22 @@ public class ByteCode {
     public static <T> T getConstantLDC(InstructionHandle h, ConstantPoolGen cpg, Class<T> clazz) {
         Instruction prevIns = h.getInstruction();
         if (prevIns instanceof LDC) {
-            LDC ldcCipher = (LDC) prevIns;
-            Object val = ldcCipher.getValue(cpg);
+            LDC ldcInst = (LDC) prevIns;
+            Object val = ldcInst.getValue(cpg);
             if (val.getClass().equals(clazz)) {
                 return clazz.cast(val);
             }
+        }
+
+        return null;
+    }
+
+    public static Integer getConstantInt(InstructionHandle h) {
+        Instruction prevIns = h.getInstruction();
+        if (prevIns instanceof ICONST) {
+            ICONST ldcCipher = (ICONST) prevIns;
+            Number num = ldcCipher.getValue();
+            return num.intValue();
         }
 
         return null;

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/cookie/CookieReadDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/cookie/CookieReadDetector.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library.
  */
-package com.h3xstream.findsecbugs.endpoint;
+package com.h3xstream.findsecbugs.cookie;
 
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
@@ -23,13 +23,13 @@ import edu.umd.cs.findbugs.Priorities;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 import org.apache.bcel.Constants;
 
-public class CookieDetector extends OpcodeStackDetector {
+public class CookieReadDetector extends OpcodeStackDetector {
 
     private static final String COOKIE_USAGE_TYPE = "COOKIE_USAGE";
 
     private BugReporter bugReporter;
 
-    public CookieDetector(BugReporter bugReporter) {
+    public CookieReadDetector(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
     }
 

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/cookie/InsecureCookieDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/cookie/InsecureCookieDetector.java
@@ -1,0 +1,135 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.cookie;
+
+import com.h3xstream.findsecbugs.common.ByteCode;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Detector;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.ba.CFG;
+import edu.umd.cs.findbugs.ba.CFGBuilderException;
+import edu.umd.cs.findbugs.ba.ClassContext;
+import edu.umd.cs.findbugs.ba.DataflowAnalysisException;
+import edu.umd.cs.findbugs.ba.Location;
+import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.Method;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.INVOKESPECIAL;
+import org.apache.bcel.generic.INVOKEVIRTUAL;
+import org.apache.bcel.generic.Instruction;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+public class InsecureCookieDetector implements Detector {
+
+    private static final String INSECURE_COOKIE_TYPE = "INSECURE_COOKIE";
+
+    private BugReporter bugReporter;
+
+    private static final int TRUE_INT_VALUE = 1;
+
+    public InsecureCookieDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void visitClassContext(ClassContext classContext) {
+        JavaClass javaClass = classContext.getJavaClass();
+
+        Method[] methodList = javaClass.getMethods();
+
+        for (Method m : methodList) {
+
+            try {
+                analyzeMethod(m,classContext);
+            } catch (CFGBuilderException e) {
+            } catch (DataflowAnalysisException e) {
+            }
+        }
+    }
+
+
+    private void analyzeMethod(Method m, ClassContext classContext) throws CFGBuilderException, DataflowAnalysisException {
+        //System.out.println("==="+m.getName()+"===");
+        ConstantPoolGen cpg = classContext.getConstantPoolGen();
+        CFG cfg = classContext.getCFG(m);
+
+        boolean newCookieCreated = false;
+        boolean secureCookieIsSet = false;
+        boolean httpOnlyCookieIsSet = false;
+
+        List<Location> cookieLocations = new ArrayList<Location>();
+
+        for (Iterator<Location> i = cfg.locationIterator(); i.hasNext(); ) {
+            Location loc = i.next();
+            //ByteCode.printOpCode(loc.getHandle().getInstruction(), cpg);
+
+
+            Instruction inst = loc.getHandle().getInstruction();
+            if(inst instanceof INVOKESPECIAL) {
+                INVOKESPECIAL invoke = (INVOKESPECIAL) inst;
+                if ("javax.servlet.http.Cookie".equals(invoke.getClassName(cpg)) &&
+                        "<init>".equals(invoke.getMethodName(cpg))){
+                    newCookieCreated = true;
+                    cookieLocations.add(loc);
+                }
+            }
+
+            else if(inst instanceof INVOKEVIRTUAL) {
+                INVOKEVIRTUAL invoke = (INVOKEVIRTUAL) inst;
+                if ("javax.servlet.http.Cookie".equals(invoke.getClassName(cpg)) &&
+                        "setSecure".equals(invoke.getMethodName(cpg))){
+                    Integer val = ByteCode.getConstantInt(loc.getHandle().getPrev());
+                    //if(val != null) System.out.println("setSecure -> "+val.intValue());
+                    if(val != null && val == TRUE_INT_VALUE) {
+                            secureCookieIsSet = true;
+                    }
+                }
+                if ("javax.servlet.http.Cookie".equals(invoke.getClassName(cpg)) &&
+                        "setHttpOnly".equals(invoke.getMethodName(cpg))){
+                    Integer val = ByteCode.getConstantInt(loc.getHandle().getPrev());
+                    if(val != null && val == TRUE_INT_VALUE) {
+                        httpOnlyCookieIsSet = true;
+                    }
+                }
+            }
+
+        }
+
+        if(newCookieCreated && !secureCookieIsSet) {
+            JavaClass clz = classContext.getJavaClass();
+
+            for(Location loc : cookieLocations) {
+                bugReporter.reportBug(new BugInstance(this, INSECURE_COOKIE_TYPE, Priorities.NORMAL_PRIORITY) //
+                        .addClass(clz)
+                        .addMethod(clz, m)
+                        .addSourceLine(classContext, m, loc));
+            }
+        }
+    }
+
+    @Override
+    public void report() {
+
+    }
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/DesUsageDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/DesUsageDetector.java
@@ -54,16 +54,51 @@ public class DesUsageDetector extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        if (seen == Constants.INVOKESTATIC && getClassConstantOperand().equals("javax/crypto/Cipher") &&
-                getNameConstantOperand().equals("getInstance")) {
-            OpcodeStack.Item item = stack.getStackItem(stack.getStackDepth() - 1); //The first argument is last
-            if (StackUtils.isConstantString(item)) {
-                String cipherValue = (String) item.getConstant();
-                if (DEBUG) System.out.println(cipherValue);
+        //printOpCode(seen);
 
-                if (cipherValue.startsWith("DES/") || cipherValue.startsWith("DESede/")) {
-                    bugReporter.reportBug(new BugInstance(this, DES_USAGE_TYPE, Priorities.NORMAL_PRIORITY) //
-                            .addClass(this).addMethod(this).addSourceLine(this));
+        //Cover Cipher.getInstance(...)
+        if (seen == Constants.INVOKESTATIC) {
+            if(getClassConstantOperand().equals("javax/crypto/Cipher") && getNameConstantOperand().equals("getInstance")) {
+                OpcodeStack.Item item;
+                if (getSigConstantOperand().equals("(Ljava/lang/String;)Ljavax/crypto/Cipher;")) {
+                    item = stack.getStackItem(0); //The first argument is last
+                } else if (getSigConstantOperand().equals("(Ljava/lang/String;Ljava/lang/String;)Ljavax/crypto/Cipher;")) {
+                    item = stack.getStackItem(1);
+                } else if (getSigConstantOperand().equals("(Ljava/lang/String;Ljava/security/Provider;)Ljavax/crypto/Cipher;")) {
+                    item = stack.getStackItem(1);
+                } else {
+                    return;
+                }
+
+
+                if (StackUtils.isConstantString(item)) {
+                    String cipherValue = ((String) item.getConstant()).toLowerCase();
+
+                    if (cipherValue.equals("des") || cipherValue.startsWith("des/") || cipherValue.startsWith("desede/")) {
+                        bugReporter.reportBug(new BugInstance(this, DES_USAGE_TYPE, Priorities.NORMAL_PRIORITY) //
+                                .addClass(this).addMethod(this).addSourceLine(this));
+                    }
+                }
+            }
+            if(getClassConstantOperand().equals("javax/crypto/KeyGenerator") && getNameConstantOperand().equals("getInstance")) {
+                OpcodeStack.Item item;
+                if (getSigConstantOperand().equals("(Ljava/lang/String;)Ljavax/crypto/KeyGenerator;")) {
+                    item = stack.getStackItem(0); //The first argument is last
+                } else if (getSigConstantOperand().equals("(Ljava/lang/String;Ljava/lang/String;)Ljavax/crypto/KeyGenerator;")) {
+                    item = stack.getStackItem(1);
+                } else if (getSigConstantOperand().equals("(Ljava/lang/String;Ljava/security/Provider;)Ljavax/crypto/KeyGenerator;")) {
+                    item = stack.getStackItem(1);
+                } else {
+                    return;
+                }
+
+                if (StackUtils.isConstantString(item)) {
+                    String cipherValue = ((String) item.getConstant()).toLowerCase();
+
+                    if (cipherValue.equals("des") || cipherValue.equals("desede")) {
+                        bugReporter.reportBug(new BugInstance(this, DES_USAGE_TYPE, Priorities.NORMAL_PRIORITY) //
+                                .addClass(this).addMethod(this).addSourceLine(this));
+                    }
                 }
             }
         }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/file/FileUploadFilenameDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/file/FileUploadFilenameDetector.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library.
  */
-package com.h3xstream.findsecbugs;
+package com.h3xstream.findsecbugs.file;
 
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/file/PathTraversalDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/file/PathTraversalDetector.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library.
  */
-package com.h3xstream.findsecbugs;
+package com.h3xstream.findsecbugs.file;
 
 import com.h3xstream.findsecbugs.common.StackUtils;
 import edu.umd.cs.findbugs.BugInstance;

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/injection/command/CommandInjectionSource.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/injection/command/CommandInjectionSource.java
@@ -17,15 +17,16 @@
  */
 package com.h3xstream.findsecbugs.injection.command;
 
+import com.h3xstream.findsecbugs.common.ByteCode;
 import com.h3xstream.findsecbugs.injection.InjectionPoint;
 import com.h3xstream.findsecbugs.injection.InjectionSource;
 import org.apache.bcel.classfile.Constant;
 import org.apache.bcel.classfile.ConstantUtf8;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.INVOKEVIRTUAL;
+import org.apache.bcel.generic.INVOKESPECIAL;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;
-
 public class CommandInjectionSource implements InjectionSource {
 
     private static final String COMMAND_INJECTION_TYPE = "COMMAND_INJECTION";
@@ -50,6 +51,8 @@ public class CommandInjectionSource implements InjectionSource {
     @Override
     public InjectionPoint getInjectableParameters(InvokeInstruction ins, ConstantPoolGen cpg, InstructionHandle insHandle) {
 
+        //ByteCode.printOpCode(ins,cpg);
+
         if (ins instanceof INVOKEVIRTUAL) {
             String methodName = ins.getMethodName(cpg);
             String className = ins.getClassName(cpg);
@@ -58,13 +61,27 @@ public class CommandInjectionSource implements InjectionSource {
                 InjectionPoint ip = new InjectionPoint(new int[]{0}, COMMAND_INJECTION_TYPE);
                 ip.setInjectableMethod("Runtime.exec(...)");
                 return ip;
-            }
-            else if (className.equals("java.lang.ProcessBuilder") && methodName.equals("command")) {
+            } else if (className.equals("java.lang.ProcessBuilder") && methodName.equals("command")) {
+                //INVOKEVIRTUAL java/lang/ProcessBuilder.command([Ljava/lang/String;)Ljava/lang/ProcessBuilder;
+                //INVOKEVIRTUAL java/lang/ProcessBuilder.command(Ljava/util/List;)Ljava/lang/ProcessBuilder;
+
                 InjectionPoint ip = new InjectionPoint(new int[]{0}, COMMAND_INJECTION_TYPE);
                 ip.setInjectableMethod("ProcessBuilder.command(...)");
                 return ip;
             }
+        } else if(ins instanceof INVOKESPECIAL) {
+            String methodName = ins.getMethodName(cpg);
+            String className = ins.getClassName(cpg);
+            if (className.equals("java.lang.ProcessBuilder") && methodName.equals("<init>")) {
+                //INVOKESPECIAL java/lang/ProcessBuilder.<init>([Ljava/lang/String;)V
+                //INVOKESPECIAL java/lang/ProcessBuilder.<init>(Ljava/util/List;)V
+
+                InjectionPoint ip = new InjectionPoint(new int[]{0}, COMMAND_INJECTION_TYPE);
+                ip.setInjectableMethod("ProcessBuilder(...)");
+                return ip;
+            }
         }
+        
         return InjectionPoint.NONE;
     }
 }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/injection/sql/SpringJdbcInjectionSource.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/injection/sql/SpringJdbcInjectionSource.java
@@ -35,7 +35,6 @@ public class SpringJdbcInjectionSource implements InjectionSource {
 
     @Override
     public InjectionPoint getInjectableParameters(InvokeInstruction ins, ConstantPoolGen cpg, InstructionHandle insHandle) {
-        //FIXME : Add the deprecated API queryForLong, queryForInt, ..
 
         //ByteCode.printOpCode(ins,cpg);
 
@@ -254,6 +253,36 @@ public class SpringJdbcInjectionSource implements InjectionSource {
                 }
                 //INVOKEVIRTUAL org/springframework/jdbc/core/JdbcTemplate.queryForRowSet ((Ljava/lang/String;[Ljava/lang/Object;[I)Lorg/springframework/jdbc/support/rowset/SqlRowSet;)
                 else if (methodSignature.equals("(Ljava/lang/String;[Ljava/lang/Object;[I)Lorg/springframework/jdbc/support/rowset/SqlRowSet;")) {
+                    return new InjectionPoint(new int[]{2}, SQL_INJECTION_TYPE);
+                }
+            }
+
+            else if (methodName.equals("queryForInt")) {
+                //INVOKEVIRTUAL org/springframework/jdbc/core/JdbcTemplate.queryForRowSet ((Ljava/lang/String;)I)
+                if (methodSignature.equals("(Ljava/lang/String;)I")) {
+                    return new InjectionPoint(new int[]{0}, SQL_INJECTION_TYPE);
+                }
+                //INVOKEVIRTUAL org/springframework/jdbc/core/JdbcTemplate.queryForRowSet ((Ljava/lang/String;[Ljava/lang/Object;)I)
+                else if (methodSignature.equals("(Ljava/lang/String;[Ljava/lang/Object;)I")) {
+                    return new InjectionPoint(new int[]{1}, SQL_INJECTION_TYPE);
+                }
+                //INVOKEVIRTUAL org/springframework/jdbc/core/JdbcTemplate.queryForRowSet ((Ljava/lang/String;[Ljava/lang/Object;[I)I)
+                else if (methodSignature.equals("(Ljava/lang/String;[Ljava/lang/Object;[I)I")) {
+                    return new InjectionPoint(new int[]{2}, SQL_INJECTION_TYPE);
+                }
+            }
+
+            else if (methodName.equals("queryForLong")) {
+                //INVOKEVIRTUAL org/springframework/jdbc/core/JdbcTemplate.queryForRowSet ((Ljava/lang/String;)J)
+                if (methodSignature.equals("(Ljava/lang/String;)J")) {
+                    return new InjectionPoint(new int[]{0}, SQL_INJECTION_TYPE);
+                }
+                //INVOKEVIRTUAL org/springframework/jdbc/core/JdbcTemplate.queryForRowSet ((Ljava/lang/String;[Ljava/lang/Object;)J)
+                else if (methodSignature.equals("(Ljava/lang/String;[Ljava/lang/Object;)J")) {
+                    return new InjectionPoint(new int[]{1}, SQL_INJECTION_TYPE);
+                }
+                //INVOKEVIRTUAL org/springframework/jdbc/core/JdbcTemplate.queryForRowSet ((Ljava/lang/String;[Ljava/lang/Object;[I)J)
+                else if (methodSignature.equals("(Ljava/lang/String;[Ljava/lang/Object;[I)J")) {
                     return new InjectionPoint(new int[]{2}, SQL_INJECTION_TYPE);
                 }
             }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
@@ -243,22 +243,33 @@ public class Taint {
 
     @Override
     public boolean equals(Object obj) {
-        // consider taint state only in equals
         if (obj == null) {
             return false;
         }
         if (!(obj instanceof Taint)) {
             return false;
         }
-        return this.state == ((Taint) obj).state;
+        Taint other = (Taint) obj;
+        return this.state == other.state
+                && this.variableIndex == other.variableIndex
+                && this.taintLocations.equals(other.taintLocations)
+                && this.unknownLocations.equals(other.unknownLocations)
+                && this.parameters.equals(other.parameters)
+                && this.nonParametricState == other.nonParametricState;
     }
 
     @Override
     public int hashCode() {
-        assert state != null;
-        return state.hashCode();
+        int hash = 3;
+        hash = 31 * hash + state.hashCode();
+        hash = 31 * hash + variableIndex;
+        hash = 31 * hash + taintLocations.hashCode();
+        hash = 31 * hash + unknownLocations.hashCode();
+        hash = 31 * hash + parameters.hashCode();
+        hash = 31 * hash + nonParametricState.hashCode();
+        return hash;
     }
-    
+
     @Override
     public String toString() {
         assert state != null;

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
@@ -231,20 +231,6 @@ public class Taint {
         result.nonParametricTaint = taint;
         }
         return result;
-        /*
-        result.taintLocations.addAll(a.taintLocations);
-        result.taintLocations.addAll(b.taintLocations);
-        result.possibleTaintLocations.addAll(a.possibleTaintLocations);
-        result.possibleTaintLocations.addAll(b.possibleTaintLocations);
-        result.taintParameters.addAll(a.taintParameters);
-        result.taintParameters.addAll(b.taintParameters);
-        Taint taint = merge(a.nonParametricTaint, b.nonParametricTaint);
-        if (a.nonParametricTaint != null && b.nonParametricTaint == null) {
-            taint = merge(taint, b);
-        } else if (b.nonParametricTaint != null && a.nonParametricTaint == null) {
-            taint = merge(taint, a);
-        }
-        */
     }
 
     @Override

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
@@ -74,11 +74,17 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
         SAFE_OBJECT_TYPES.add("Ljava/lang/Long;");
         SAFE_OBJECT_TYPES.add("Ljava/lang/Byte;");
         SAFE_OBJECT_TYPES.add("Ljava/lang/Short;");
-        SAFE_OBJECT_TYPES.add("Ljava/lang/BigDecimal;");
+        SAFE_OBJECT_TYPES.add("Ljava/math/BigDecimal;");
         // these data types are not modified, when passed as a parameter to an unknown method
         IMMUTABLE_OBJECT_TYPES = new HashSet<String>(SAFE_OBJECT_TYPES.size() + 1);
         IMMUTABLE_OBJECT_TYPES.addAll(SAFE_OBJECT_TYPES);
         IMMUTABLE_OBJECT_TYPES.add("Ljava/lang/String;");
+        IMMUTABLE_OBJECT_TYPES.add("Ljava/math/BigInteger;");
+        IMMUTABLE_OBJECT_TYPES.add("Ljava/io/File;");
+        IMMUTABLE_OBJECT_TYPES.add("Ljava/util/Locale;");
+        IMMUTABLE_OBJECT_TYPES.add("Ljava/net/Inet4Address;");
+        IMMUTABLE_OBJECT_TYPES.add("Ljava/net/Inet6Address;");
+        IMMUTABLE_OBJECT_TYPES.add("Ljava/net/InetSocketAddress;");
     }
 
     public TaintFrameModelingVisitor(ConstantPoolGen cpg, MethodDescriptor method,

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
@@ -55,7 +55,7 @@ import org.apache.bcel.generic.StoreInstruction;
  */
 public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Taint, TaintFrame> {
 
-    private static final String TO_STRING_METHOD = "toString()Ljava/lang/String;";
+    private static final String TOSTRING_METHOD = "toString()Ljava/lang/String;";
     private static final String EQUALS_METHOD = "equals(Ljava/lang/Object;)Z";
     private static final Set<String> SAFE_OBJECT_TYPES;
     private static final Set<String> IMMUTABLE_OBJECT_TYPES;
@@ -76,7 +76,7 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
         SAFE_OBJECT_TYPES.add("Ljava/lang/Short;");
         SAFE_OBJECT_TYPES.add("Ljava/math/BigDecimal;");
         // these data types are not modified, when passed as a parameter to an unknown method
-        IMMUTABLE_OBJECT_TYPES = new HashSet<String>(SAFE_OBJECT_TYPES.size() + 1);
+        IMMUTABLE_OBJECT_TYPES = new HashSet<String>(SAFE_OBJECT_TYPES.size() + 7);
         IMMUTABLE_OBJECT_TYPES.addAll(SAFE_OBJECT_TYPES);
         IMMUTABLE_OBJECT_TYPES.add("Ljava/lang/String;");
         IMMUTABLE_OBJECT_TYPES.add("Ljava/math/BigInteger;");
@@ -183,7 +183,7 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
         while (numProduced-- > 0) {
             Taint value = getFrame().getValue(--index);
             assert value.hasValidVariableIndex() : "index not set in " + methodDescriptor;
-            assert index == value.getVariableIndex(): "bad index in " + methodDescriptor;
+            assert index == value.getVariableIndex() : "bad index in " + methodDescriptor;
             getFrame().pushValue(new Taint(value));
         }
     }
@@ -288,7 +288,7 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
         if (methodSummary != null) {
             return methodSummary;
         }
-        if (TO_STRING_METHOD.equals(methodNameWithSig)) {
+        if (TOSTRING_METHOD.equals(methodNameWithSig)) {
             return TaintMethodSummary.DEFAULT_TOSTRING_SUMMARY;
         }
         if (EQUALS_METHOD.equals(methodNameWithSig)) {
@@ -349,7 +349,7 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
                 Taint taint = Taint.merge(stackValue, getDefaultValue());
                 if (stackValue.hasValidVariableIndex()) {
                     // set back the index removed during merging
-                    taint.setVariableIndex(stackValue.getVariableIndex()); 
+                    taint.setVariableIndex(stackValue.getVariableIndex());
                 }
                 taint.addLocation(getTaintLocation(), false);
                 getFrame().setValue(getFrame().getStackLocation(index), taint);
@@ -359,7 +359,7 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
             }
         }
     }
-    
+
     private Taint mergeTransferParameters(Collection<Integer> transferParameters) {
         assert transferParameters != null && !transferParameters.isEmpty();
         Taint taint = null;
@@ -412,7 +412,7 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
         valueTaint.setVariableIndex(index);
         getFrame().setValue(index, valueTaint);
     }
-    
+
     private void pushSafe() {
         getFrame().pushValue(new Taint(Taint.State.SAFE));
     }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodSummary.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodSummary.java
@@ -151,9 +151,8 @@ public class TaintMethodSummary {
 
     /**
      * Loads method summary from String
-     *
-     * @param str (state or parameter indeces to merge separated by
-     * comma)#mutable position
+     * 
+     * @param str (state or parameter indices to merge separated by comma)#mutable position
      * @return initialized object with taint method summary
      * @throws java.io.IOException for bad format of paramter
      */

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodSummaryMap.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodSummaryMap.java
@@ -34,7 +34,7 @@ public class TaintMethodSummaryMap extends HashMap<String, TaintMethodSummary> {
     private static final long serialVersionUID = 1L;
     
     public void load(InputStream input) throws IOException {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(input, "UTF-8"));
         for (;;) {
                 String line = reader.readLine();
                 if (line == null) {

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -18,8 +18,9 @@
     <Detector class="com.h3xstream.findsecbugs.PredictableRandomDetector" reports="PREDICTABLE_RANDOM"/>
     <Detector class="com.h3xstream.findsecbugs.endpoint.ServletEndpointDetector"
               reports="SERVLET_PARAMETER,SERVLET_CONTENT_TYPE,SERVLET_SERVER_NAME,SERVLET_SESSION_ID,SERVLET_QUERY_STRING,SERVLET_HEADER,SERVLET_HEADER_REFERER,SERVLET_HEADER_USER_AGENT"/>
-    <Detector class="com.h3xstream.findsecbugs.endpoint.CookieDetector" reports="COOKIE_USAGE"/>
-    <Detector class="com.h3xstream.findsecbugs.PathTraversalDetector" reports="PATH_TRAVERSAL_IN,PATH_TRAVERSAL_OUT"/>
+    <Detector class="com.h3xstream.findsecbugs.cookie.CookieReadDetector" reports="COOKIE_USAGE"/>
+    <Detector class="com.h3xstream.findsecbugs.cookie.InsecureCookieDetector" reports="INSECURE_COOKIE"/>
+    <Detector class="com.h3xstream.findsecbugs.file.PathTraversalDetector" reports="PATH_TRAVERSAL_IN,PATH_TRAVERSAL_OUT"/>
     <Detector class="com.h3xstream.findsecbugs.injection.command.CommandInjectionDetector" reports="COMMAND_INJECTION"/>
     <Detector class="com.h3xstream.findsecbugs.WeakFilenameUtilsMethodDetector" reports="WEAK_FILENAMEUTILS"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.WeakTrustManagerDetector" reports="WEAK_TRUST_MANAGER"/>
@@ -29,7 +30,7 @@
     <Detector class="com.h3xstream.findsecbugs.endpoint.WicketEndpointDetector" reports="WICKET_ENDPOINT"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.WeakMessageDigestDetector" reports="WEAK_MESSAGE_DIGEST"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.CustomMessageDigestDetector" reports="CUSTOM_MESSAGE_DIGEST"/>
-    <Detector class="com.h3xstream.findsecbugs.FileUploadFilenameDetector" reports="FILE_UPLOAD_FILENAME"/>
+    <Detector class="com.h3xstream.findsecbugs.file.FileUploadFilenameDetector" reports="FILE_UPLOAD_FILENAME"/>
     <Detector class="com.h3xstream.findsecbugs.ReDosDetector" reports="REDOS"/>
     <Detector class="com.h3xstream.findsecbugs.xxe.SaxParserXxeDetector" reports="XXE_SAXPARSER,XXE_XMLREADER,XXE_DOCUMENT"/>
     <Detector class="com.h3xstream.findsecbugs.xpath.XPathInjectionJavaxDetector" reports="XPATH_INJECTION"/>
@@ -78,6 +79,7 @@
     <BugPattern type="SERVLET_HEADER_REFERER" abbrev="SECSHR" category="SECURITY"/>
     <BugPattern type="SERVLET_HEADER_USER_AGENT" abbrev="SECSHUA" category="SECURITY"/>
     <BugPattern type="COOKIE_USAGE" abbrev="SECCU" category="SECURITY"/>
+    <BugPattern type="INSECURE_COOKIE" abbrev="SECIC" category="SECURITY"/>
     <BugPattern type="PATH_TRAVERSAL_IN" abbrev="SECPTI" category="SECURITY"/>
     <BugPattern type="PATH_TRAVERSAL_OUT" abbrev="SECPTO" category="SECURITY"/>
     <BugPattern type="COMMAND_INJECTION" abbrev="SECCI" category="SECURITY"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -268,7 +268,7 @@ crawler UA) is not recommended.</p>
 
 
     <!-- Cookie usage -->
-    <Detector class="com.h3xstream.findsecbugs.endpoint.CookieDetector">
+    <Detector class="com.h3xstream.findsecbugs.cookie.CookieReadDetector">
         <Details>Identity direct cookie usage</Details>
     </Detector>
 
@@ -292,7 +292,7 @@ and referenced by the user's session cookie. See HttpSession (HttpServletRequest
 
 
     <!-- Path traversal -->
-    <Detector class="com.h3xstream.findsecbugs.PathTraversalDetector">
+    <Detector class="com.h3xstream.findsecbugs.file.PathTraversalDetector">
         <Details>Identify filesystem access requests that take a path as a parameter.</Details>
     </Detector>
 
@@ -642,7 +642,7 @@ sha256Digest.update(password.getBytes());</pre>
 
 
     <!-- FileUpload Filename -->
-    <Detector class="com.h3xstream.findsecbugs.FileUploadFilenameDetector">
+    <Detector class="com.h3xstream.findsecbugs.file.FileUploadFilenameDetector">
         <Details>The filename given by FileUpload API can be tampered with by the client.</Details>
     </Detector>
 
@@ -1268,8 +1268,21 @@ The input values included in SQL queries need to be passed in safely.
 Bind variables in prepared statements can be used to easily mitigate the risk of SQL injection.
 </p>
 
-TODO
+<p>
+    <b>Vulnerable Code:</b><br/>
+    <pre>JdbcTemplate jdbc = new JdbcTemplate();
+int count = jdbc.queryForObject("select count(*) from Users where name = '"+paramName+"'", Integer.class);
+</pre>
+</p>
+<p>
+    <b>Solution:</b><br/>
+    <pre>JdbcTemplate jdbc = new JdbcTemplate();
+int count = jdbc.queryForObject("select count(*) from Users where name = ?", Integer.class, paramName);</pre>
+</p>
+<br/>
 
+<b>References (Spring JDBC)</b><br/>
+<a href="http://docs.spring.io/spring-framework/docs/current/spring-framework-reference/html/jdbc.html">Spring Official Documentation: Data access with JDBC</a><br/>
 <b>References (SQL injection)</b><br/>
 <a href="http://projects.webappsec.org/w/page/13246963/SQL%20Injection">WASC-19: SQL Injection</a><br/>
 <a href="http://capec.mitre.org/data/definitions/66.html">CAPEC-66: SQL Injection</a><br/>
@@ -1294,8 +1307,23 @@ The input values included in SQL queries need to be passed in safely.
 Bind variables in prepared statements can be used to easily mitigate the risk of SQL injection.
 </p>
 
-TODO
+<p>
+    <b>Vulnerable Code:</b><br/>
+    <pre>Connection conn = [...];
+Statement stmt = con.createStatement();
+ResultSet rs = stmt.executeQuery("update COFFEES set SALES = "+nbSales+" where COF_NAME = '"+coffeeName+"'");</pre>
+</p>
+<p>
+    <b>Solution:</b><br/>
+    <pre>Connection conn = [...];
+conn.prepareStatement("update COFFEES set SALES = ? where COF_NAME = ?");
+updateSales.setInt(1, nbSales);
+updateSales.setString(2, coffeeName);</pre>
+</p>
+<br/>
 
+<b>References (JDBC)</b><br/>
+<a href="http://docs.oracle.com/javase/tutorial/jdbc/basics/prepared.html">Oracle Documentation: The Java Tutorials &gt; Prepared Statements</a><br/>
 <b>References (SQL injection)</b><br/>
 <a href="http://projects.webappsec.org/w/page/13246963/SQL%20Injection">WASC-19: SQL Injection</a><br/>
 <a href="http://capec.mitre.org/data/definitions/66.html">CAPEC-66: SQL Injection</a><br/>
@@ -2703,5 +2731,66 @@ class FileWriteUtil {
         </Details>
     </BugPattern>
     <BugCode abbrev="SECWVJI">WebView with a Java bridge (Javascript Interface) (Android)</BugCode>
+
+    <!-- Cookie usage -->
+    <Detector class="com.h3xstream.findsecbugs.cookie.InsecureCookieDetector">
+        <Details>Identity cookie where the secure flag is not set</Details>
+    </Detector>
+
+    <BugPattern type="INSECURE_COOKIE">
+        <ShortDescription>Cookie without the secure flag</ShortDescription>
+        <LongDescription>Cookie without the secure flag could be sent in cleartext if a HTTP URL is visited.</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+A new cookie is created without the <code>Secure</code> flag set.
+The <code>Secure</code> flag is a directive to the browser to make sure that the cookie is not sent for insecure
+communication (<code>http://</code>).
+</p>
+
+<p>
+<b>Code at risk:</b><br/>
+<pre>
+Cookie cookie = new Cookie("userName",userName);
+response.addCookie(cookie);
+</pre>
+</p>
+
+<p>
+<b>Solution (Specific configuration):</b><br/>
+<pre>
+Cookie cookie = new Cookie("userName",userName);
+cookie.setSecure(true);
+cookie.setHttpOnly(true);
+</pre>
+</p>
+
+<p>
+<b>Solution (Servlet 3.0 configuration):</b><br/>
+<pre>
+&lt;web-app xmlns="http://java.sun.com/xml/ns/javaee" version="3.0"&gt;
+[...]
+&lt;session-config&gt;
+ &lt;cookie-config&gt;
+  &lt;http-only&gt;true&lt;/http-only&gt;
+  &lt;secure&gt;true&lt;/secure&gt;
+ &lt;/cookie-config&gt;
+&lt;/session-config&gt;
+&lt;/web-app&gt;
+</pre>
+</p>
+<br/>
+<p>
+<b>Reference</b><br/>
+<a href="https://cwe.mitre.org/data/definitions/614.html">CWE-614: Sensitive Cookie in HTTPS Session Without 'Secure' Attribute</a><br/>
+<a href="https://cwe.mitre.org/data/definitions/315.html">CWE-315: Cleartext Storage of Sensitive Information in a Cookie</a><br/>
+<a href="https://cwe.mitre.org/data/definitions/311.html">CWE-311: Missing Encryption of Sensitive Data</a><br/>
+<a href="https://www.owasp.org/index.php/SecureFlag">OWASP: Secure Flag</a><br/>
+<a href="https://www.rapid7.com/db/vulnerabilities/http-cookie-secure-flag">Rapid7: Missing Secure Flag From SSL Cookie</a>
+</p>
+]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECIC">Cookie without the secure flag</BugCode>
 
 </MessageCollection>

--- a/plugin/src/main/resources/metadata/messages_ja.xml
+++ b/plugin/src/main/resources/metadata/messages_ja.xml
@@ -264,7 +264,7 @@ Cookie: JSESSIONID=Any value of the user&#39;s choice!!??'''&quot;&gt;
 
 
     <!-- Cookie usage -->
-    <Detector class="com.h3xstream.findsecbugs.endpoint.CookieDetector">
+    <Detector class="com.h3xstream.findsecbugs.cookie.CookieReadDetector">
         <Details>直接的なクッキーの利用を特定します。</Details>
     </Detector>
 
@@ -288,7 +288,7 @@ HttpSession (HttpServletRequest.getSession()) を参照してください。</p>
 
 
     <!-- Path traversal -->
-    <Detector class="com.h3xstream.findsecbugs.PathTraversalDetector">
+    <Detector class="com.h3xstream.findsecbugs.file.PathTraversalDetector">
         <Details>パラメーターを通じたファイルシステムへのアクセス要求を特定します。</Details>
     </Detector>
 
@@ -631,7 +631,7 @@ sha256Digest.update(password.getBytes());</pre>
 
 
     <!-- FileUpload Filename -->
-    <Detector class="com.h3xstream.findsecbugs.FileUploadFilenameDetector">
+    <Detector class="com.h3xstream.findsecbugs.file.FileUploadFilenameDetector">
         <Details>ファイルアップロード API によって与えられたファイル名はクライアントによって改ざんされていることがあります。</Details>
     </Detector>
 
@@ -1243,6 +1243,85 @@ UserEntity res = q.getSingleResult();</pre>
     </BugPattern>
     <BugCode abbrev="SECSQLIJPA">SQL インジェクション (JPA)</BugCode>
 
+    <!-- SPRING JDBC Injection -->
+    <BugPattern type="SQL_INJECTION_SPRING_JDBC">
+        <ShortDescription>潜在的な JDBC インジェクション (Spring JDBC)</ShortDescription>
+        <LongDescription>このクエリーは、SQL/JPQL インジェクションに脆弱な可能性があります。</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+SQL クエリーに含まれる入力値は安全に渡される必要があります。
+プリペアードステートメントのバインド変数は、SQL インジェクションのリスクを容易に軽減するために使用することができます。
+</p>
+
+<p>
+    <b>脆弱なコード:</b><br/>
+    <pre>JdbcTemplate jdbc = new JdbcTemplate();
+int count = jdbc.queryForObject("select count(*) from Users where name = '"+paramName+"'", Integer.class);
+</pre>
+</p>
+<p>
+    <b>解決策:</b><br/>
+    <pre>JdbcTemplate jdbc = new JdbcTemplate();
+int count = jdbc.queryForObject("select count(*) from Users where name = ?", Integer.class, paramName);</pre>
+</p>
+<br/>
+
+<b>参考文献 (Spring JDBC)</b><br/>
+<a href="http://docs.spring.io/spring-framework/docs/current/spring-framework-reference/html/jdbc.html">Spring Official Documentation: Data access with JDBC</a><br/>
+<b>参考文献 (SQL インジェクション)</b><br/>
+<a href="http://projects.webappsec.org/w/page/13246963/SQL%20Injection">WASC-19: SQL Injection</a><br/>
+<a href="http://capec.mitre.org/data/definitions/66.html">CAPEC-66: SQL Injection</a><br/>
+<a href="http://cwe.mitre.org/data/definitions/89.html">CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')</a><br/>
+<a href="https://www.owasp.org/index.php/Top_10_2013-A1-Injection">OWASP: Top 10 2013-A1-Injection</a><br/>
+<a href="https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet">OWASP: SQL Injection Prevention Cheat Sheet</a><br/>
+<a href="https://www.owasp.org/index.php/Query_Parameterization_Cheat_Sheet">OWASP: Query Parameterization Cheat Sheet</a><br/>
+</p>
+]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECSQLISPRJDBC">SQL インジェクション (Spring JDBC)</BugCode>
+
+    <!-- JDBC Injection -->
+    <BugPattern type="SQL_INJECTION_JDBC">
+        <ShortDescription>潜在的な JDBC インジェクション</ShortDescription>
+        <LongDescription>このクエリーは、SQL/JPQL インジェクションに脆弱な可能性があります。</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+SQL クエリーに含まれる入力値は安全に渡される必要があります。
+プリペアードステートメントのバインド変数は、SQL インジェクションのリスクを容易に軽減するために使用することができます。
+</p>
+
+<p>
+    <b>脆弱なコード:</b><br/>
+    <pre>Connection conn = [...];
+Statement stmt = con.createStatement();
+ResultSet rs = stmt.executeQuery("update COFFEES set SALES = "+nbSales+" where COF_NAME = '"+coffeeName+"'");</pre>
+</p>
+<p>
+    <b>解決策:</b><br/>
+    <pre>Connection conn = [...];
+conn.prepareStatement("update COFFEES set SALES = ? where COF_NAME = ?");
+updateSales.setInt(1, nbSales);
+updateSales.setString(2, coffeeName);</pre>
+</p>
+<br/>
+
+<b>参考文献 (JDBC)</b><br/>
+<a href="http://docs.oracle.com/javase/tutorial/jdbc/basics/prepared.html">Oracle Documentation: The Java Tutorials &gt; Prepared Statements</a><br/>
+<b>参考文献 (SQL インジェクション)</b><br/>
+<a href="http://projects.webappsec.org/w/page/13246963/SQL%20Injection">WASC-19: SQL Injection</a><br/>
+<a href="http://capec.mitre.org/data/definitions/66.html">CAPEC-66: SQL Injection</a><br/>
+<a href="http://cwe.mitre.org/data/definitions/89.html">CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')</a><br/>
+<a href="https://www.owasp.org/index.php/Top_10_2013-A1-Injection">OWASP: Top 10 2013-A1-Injection</a><br/>
+<a href="https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet">OWASP: SQL Injection Prevention Cheat Sheet</a><br/>
+<a href="https://www.owasp.org/index.php/Query_Parameterization_Cheat_Sheet">OWASP: Query Parameterization Cheat Sheet</a><br/>
+</p>
+]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECSQLIJDBC">SQL インジェクション (JDBC)</BugCode>
 
     <!-- LDAP Injection -->
     <Detector class="com.h3xstream.findsecbugs.injection.ldap.LdapInjectionDetector">

--- a/plugin/src/main/resources/taint-config/methods-summaries.txt
+++ b/plugin/src/main/resources/taint-config/methods-summaries.txt
@@ -294,21 +294,14 @@ java/util/LinkedList.retainAll(Ljava/util/Collection;)Z:1
 java/util/LinkedList.replaceAll(Ljava/util/function/UnaryOperator;)V:1#1
 java/util/LinkedList.removeIf(Ljava/util/function/Predicate;)Z:1#1
 
--Injection API should not alter their parameters (The following signature should be removed at long term)
 
--javax/jdo/PersistenceManager.newQuery(Ljava/lang/Class;Ljava/util/Collection;)Ljavax/jdo/Query;:UNKNOWN
--javax/jdo/PersistenceManager.newQuery(Ljava/lang/Class;Ljava/util/Collection;Ljava/lang/String;)Ljavax/jdo/Query;:UNKNOWN
+java/util/Arrays.asList([Ljava/lang/Object;)Ljava/util/List;:0
+
+
+- The following methods receive arguments but will not alter the objects received. (It avoids tainting the parameters that are not immutable.)
+
 javax/jdo/PersistenceManager.newQuery(Ljava/lang/Object;)Ljavax/jdo/Query;:UNKNOWN
 javax/jdo/PersistenceManager.newQuery(Ljava/lang/String;Ljava/lang/Object;)Ljavax/jdo/Query;:UNKNOWN
-
--com/unboundid/ldap/sdk/LDAPConnection.search(Ljava/lang/String;Lcom/unboundid/ldap/sdk/SearchScope;Ljava/lang/String;[Ljava/lang/String;)Lcom/unboundid/ldap/sdk/SearchResult;:UNKNOWN
-
--org/hibernate/criterion/Restrictions.sqlRestriction(Ljava/lang/String;Ljava/lang/Object;Lorg/hibernate/type/Type;)Lorg/hibernate/criterion/Criterion;:UNKNOWN
--org/hibernate/criterion/Restrictions.sqlRestriction(Ljava/lang/String;[Ljava/lang/Object;[Lorg/hibernate/type/Type;)Lorg/hibernate/criterion/Criterion;:UNKNOWN
--org/hibernate/criterion/Restrictions.sqlRestriction(Ljava/lang/String;)Lorg/hibernate/criterion/Criterion;:UNKNOWN
--org/hibernate/criterion/Restrictions.sqlRestriction(Ljava/lang/String;Ljava/lang/Object;Lorg/hibernate/type/Type;)Lorg/hibernate/criterion/Criterion;:UNKNOWN
--org/hibernate/criterion/Restrictions.sqlRestriction(Ljava/lang/String;[Ljava/lang/Object;[Lorg/hibernate/type/Type;)Lorg/hibernate/criterion/Criterion;:UNKNOWN
-
 
 java/util/logging/Logger.entering(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V:UNKNOWN
 java/util/logging/Logger.entering(Ljava/lang/String;Ljava/lang/String;[Ljava/lang/Object;)V:UNKNOWN

--- a/plugin/src/main/resources/taint-config/methods-summaries.txt
+++ b/plugin/src/main/resources/taint-config/methods-summaries.txt
@@ -46,9 +46,9 @@ java/sql/ResultSet.getString(Ljava/lang/String;)Ljava/lang/String;:TAINTED
 
 
 java/lang/StringBuilder.<init>()V:SAFE
-java/lang/StringBuilder.<init>(Ljava/lang/CharSequence;)V:0#1
+java/lang/StringBuilder.<init>(Ljava/lang/CharSequence;)V:0#1,2
 java/lang/StringBuilder.<init>(I)V:SAFE
-java/lang/StringBuilder.<init>(Ljava/lang/String;)V:0#1
+java/lang/StringBuilder.<init>(Ljava/lang/String;)V:0#1,2
 
 java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;:0,1#1
 java/lang/StringBuilder.append(Ljava/lang/StringBuffer;)Ljava/lang/StringBuilder;:0,1#1
@@ -86,9 +86,9 @@ java/lang/StringBuilder.trimToSize()V:0#0
 
 
 java/lang/StringBuffer.<init>()V:SAFE
-java/lang/StringBuffer.<init>(Ljava/lang/CharSequence;)V:0#1
+java/lang/StringBuffer.<init>(Ljava/lang/CharSequence;)V:0#1,2
 java/lang/StringBuffer.<init>(I)V:SAFE
-java/lang/StringBuffer.<init>(Ljava/lang/String;)V:0#1
+java/lang/StringBuffer.<init>(Ljava/lang/String;)V:0#1,2
 
 java/lang/StringBuffer.append(Ljava/lang/String;)Ljava/lang/StringBuffer;:0,1#1
 java/lang/StringBuffer.append(Ljava/lang/StringBuffer;)Ljava/lang/StringBuffer;:0,1#1
@@ -126,9 +126,9 @@ java/lang/StringBuffer.trimToSize()V:0#0
 
 
 java/lang/String.<init>()V:SAFE
-java/lang/String.<init>(Ljava/lang/String;)V:0#1
-java/lang/String.<init>(Ljava/lang/StringBuilder;)V:0#1
-java/lang/String.<init>(Ljava/lang/StringBuffer;)V:0#1
+java/lang/String.<init>(Ljava/lang/String;)V:0#1,2
+java/lang/String.<init>(Ljava/lang/StringBuilder;)V:0#1,2
+java/lang/String.<init>(Ljava/lang/StringBuffer;)V:0#1,2
 
 java/lang/String.concat(Ljava/lang/String;)Ljava/lang/String;:0,1
 java/lang/String.intern()Ljava/lang/String;:0
@@ -157,9 +157,9 @@ java/lang/String.valueOf(Ljava/lang/Object)Ljava/lang/String;:0,1
 java/lang/CharSequence.subSequence(II)Ljava/lang/CharSequence;:2
 
 
-java/util/StringTokenizer.<init>(Ljava/lang/String;)V:0#1
-java/util/StringTokenizer.<init>(Ljava/lang/String;Ljava/lang/String;)V:1#2
-java/util/StringTokenizer.<init>(Ljava/lang/String;Ljava/lang/String;B)V:2#3
+java/util/StringTokenizer.<init>(Ljava/lang/String;)V:0#1,2
+java/util/StringTokenizer.<init>(Ljava/lang/String;Ljava/lang/String;)V:1#2,3
+java/util/StringTokenizer.<init>(Ljava/lang/String;Ljava/lang/String;B)V:2#3,4
 java/util/StringTokenizer.nextToken()Ljava/lang/String;:0
 java/util/StringTokenizer.nextToken(Ljava/lang/String;)Ljava/lang/String;:1
 
@@ -198,7 +198,7 @@ java/lang/BigDecimal.toString()Ljava/lang/String;:SAFE
 java/util/Collection.add(Ljava/lang/Object;)Z:0,1#1
 java/util/Collection.add(Ljava/lang/Object;)Z:0,1#1
 java/util/Collection.addAll(Ljava/util/Collection;)Z:0,1#1
--java/util/Collection.clear()V:SAFE#0
+java/util/Collection.clear()V:SAFE#0
 java/util/Collection.remove(Ljava/lang/Object;)Z:1
 java/util/Collection.removeAll(Ljava/util/Collection;)Z:1
 java/util/Collection.removeIf(Ljava/util/function/Predicate;)Z:1#1
@@ -211,7 +211,7 @@ java/util/List.add(Ljava/lang/Object;)Z:0,1#1
 java/util/List.add(ILjava/lang/Object;)V:0,2#2
 java/util/List.addAll(Ljava/util/Collection;)Z:0,1#1
 java/util/List.addAll(ILjava/util/Collection;)Z:0,2#2
--java/util/List.clear()V:SAFE#0
+java/util/List.clear()V:SAFE#0
 java/util/List.get(I)Ljava/lang/Object;:1
 java/util/List.remove()Ljava/lang/Object;:0
 java/util/List.remove(I)Ljava/lang/Object;:1
@@ -230,12 +230,12 @@ java/util/List.forEach(Ljava/util/function/Consumer;)V:1
 
 java/util/ArrayList.<init>()V:SAFE
 java/util/ArrayList.<init>(I)V:SAFE
-java/util/ArrayList.<init>(Ljava/util/Collection;)V:0#1
+java/util/ArrayList.<init>(Ljava/util/Collection;)V:0#1,2
 java/util/ArrayList.add(Ljava/lang/Object;)Z:0,1#1
 java/util/ArrayList.add(ILjava/lang/Object;)V:0,2#2
 java/util/ArrayList.addAll(Ljava/util/Collection;)Z:0,1#1
 java/util/ArrayList.addAll(ILjava/util/Collection;)Z:0,2#2
--java/util/ArrayList.clear()V:SAFE#0
+java/util/ArrayList.clear()V:SAFE#0
 java/util/ArrayList.ensureCapacity(I)V:1
 java/util/ArrayList.forEach(Ljava/util/function/Consumer;)V:1
 java/util/ArrayList.get(I)Ljava/lang/Object;:1
@@ -255,14 +255,14 @@ java/util/ArrayList.trimToSize()V:0
 
 
 java/util/LinkedList.<init>()V:SAFE
-java/util/LinkedList.<init>(Ljava/util/Collection;)V:0#1
+java/util/LinkedList.<init>(Ljava/util/Collection;)V:0#1,2
 java/util/LinkedList.add(Ljava/lang/Object;)Z:0,1#1
 java/util/LinkedList.add(ILjava/lang/Object;)V:0,2#2
 java/util/LinkedList.addAll(Ljava/util/Collection;)Z:0,1#1
 java/util/LinkedList.addAll(ILjava/util/Collection;)Z:0,2#2
 java/util/LinkedList.addFirst(Ljava/lang/Object;)V:0,1#1
 java/util/LinkedList.addLast(Ljava/lang/Object;)V:0,1#1
--java/util/LinkedList.clear()V:SAFE#0
+java/util/LinkedList.clear()V:SAFE#0
 java/util/LinkedList.element()Ljava/lang/Object;:0
 java/util/LinkedList.get(I)Ljava/lang/Object;:1
 java/util/LinkedList.getFirst()Ljava/lang/Object;:0

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/cookie/CookieReadDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/cookie/CookieReadDetectorTest.java
@@ -15,41 +15,37 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library.
  */
-package com.h3xstream.findsecbugs;
+package com.h3xstream.findsecbugs.cookie;
 
 import com.h3xstream.findbugs.test.BaseDetectorTest;
 import com.h3xstream.findbugs.test.EasyBugReporter;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-public class FileUploadFilenameDetectorTest extends BaseDetectorTest {
+public class CookieReadDetectorTest extends BaseDetectorTest {
 
     @Test
-    public void detectTaintedFilename() throws Exception {
+    public void detectCookieUsage() throws Exception {
         //Locate test code
         String[] files = {
-                getClassFilePath("testcode/FileUploadCommon"),
-                getClassFilePath("testcode/FileUploadWicket")
+                getClassFilePath("testcode/cookie/CookieUsage")
         };
 
         //Run the analysis
         EasyBugReporter reporter = spy(new EasyBugReporter());
         analyze(files, reporter);
 
-        verify(reporter).doReportBug(
-                bugDefinition()
-                        .bugType("FILE_UPLOAD_FILENAME")
-                        .inClass("FileUploadWicket").inMethod("handleFile").atLine(16)
-                        .build()
-        );
-
-        verify(reporter).doReportBug(
-                bugDefinition()
-                        .bugType("FILE_UPLOAD_FILENAME")
-                        .inClass("FileUploadCommon").inMethod("handleFile").atLine(17)
-                        .build()
-        );
+        for (Integer line : Arrays.asList(15, 16, 17)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("COOKIE_USAGE")
+                            .inClass("CookieUsage").inMethod("doGet").atLine(line)
+                            .build()
+            );
+        }
     }
 }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/cookie/InsecureCookieDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/cookie/InsecureCookieDetectorTest.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library.
  */
-package com.h3xstream.findsecbugs;
+package com.h3xstream.findsecbugs.cookie;
 
 import com.h3xstream.findbugs.test.BaseDetectorTest;
 import com.h3xstream.findbugs.test.EasyBugReporter;
@@ -23,36 +23,49 @@ import org.testng.annotations.Test;
 
 import java.util.Arrays;
 
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-public class PathTraversalDetectorTest extends BaseDetectorTest {
+public class InsecureCookieDetectorTest extends BaseDetectorTest {
 
     @Test
-    public void detectPathTraversal() throws Exception {
+    public void detectInsecureCookieBasic() throws Exception {
         //Locate test code
         String[] files = {
-                getClassFilePath("testcode/PathTraversal")
+                getClassFilePath("testcode/cookie/InsecureCookieSamples")
         };
 
         //Run the analysis
         EasyBugReporter reporter = spy(new EasyBugReporter());
         analyze(files, reporter);
 
-        for (Integer line : Arrays.asList(10, 11, 13, 15, 17)) {
+        for (String method : Arrays.asList("unsafeCookie1", "unsafeCookie2", "unsafeCookie4", "unsafeCookie5")) {
             verify(reporter).doReportBug(
                     bugDefinition()
-                            .bugType("PATH_TRAVERSAL_IN")
-                            .inClass("PathTraversal").inMethod("main").atLine(line)
+                            .bugType("INSECURE_COOKIE")
+                            .inClass("InsecureCookieSamples").inMethod(method)
                             .build()
             );
         }
+    }
 
-        for (Integer line : Arrays.asList(20, 21, 23, 24)) {
-            verify(reporter).doReportBug(
+    @Test
+    public void avoidBasicFalsePositive() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/cookie/InsecureCookieSamples")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new EasyBugReporter());
+        analyze(files, reporter);
+
+        for (String method : Arrays.asList("safeCookie1", "safeCookie2")) {
+            verify(reporter,never()).doReportBug(
                     bugDefinition()
-                            .bugType("PATH_TRAVERSAL_OUT")
-                            .inClass("PathTraversal").inMethod("main").atLine(line)
+                            .bugType("INSECURE_COOKIE")
+                            .inClass("InsecureCookieSamples").inMethod(method)
                             .build()
             );
         }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/EcbModeDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/EcbModeDetectorTest.java
@@ -44,7 +44,7 @@ public class EcbModeDetectorTest extends BaseDetectorTest {
 
         //Assertions
 
-        for (Integer line : Arrays.asList(18, 19, 22, 23, 26, 27)) {
+        for (Integer line : Arrays.asList(18, 19, 22, 23, 26, 27, 34)) {
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("ECB_MODE")
@@ -56,7 +56,7 @@ public class EcbModeDetectorTest extends BaseDetectorTest {
         }
 
         //The count make sure no other bug are detect
-        verify(reporter, times(6)).doReportBug(
+        verify(reporter, times(7)).doReportBug(
                 bugDefinition()
                         .bugType("ECB_MODE")
                         .inClass("BlockCipherList")

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/WeakMessageDigestDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/WeakMessageDigestDetectorTest.java
@@ -85,4 +85,33 @@ public class WeakMessageDigestDetectorTest extends BaseDetectorTest {
                         .build()
         );
     }
+
+    @Test
+    public void detectWeakDigestAdditionalSignatures() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/crypto/WeakMessageDigestAdditionalSig")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new EasyBugReporter());
+        analyze(files, reporter);
+
+        //Message Digest
+        for(int line : Arrays.asList(11,12,13,14,15,16,17,18,19,20,21)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("WEAK_MESSAGE_DIGEST")
+                            .inClass("WeakMessageDigestAdditionalSig").inMethod("weakDigestMoreSig").atLine(line)
+                            .build()
+            );
+        }
+
+        verify(reporter,times(11)).doReportBug(
+                bugDefinition()
+                        .bugType("WEAK_MESSAGE_DIGEST")
+                        .inClass("WeakMessageDigestAdditionalSig").inMethod("weakDigestMoreSig")
+                        .build()
+        );
+    }
 }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/file/FileUploadFilenameDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/file/FileUploadFilenameDetectorTest.java
@@ -15,23 +15,23 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library.
  */
-package com.h3xstream.findsecbugs.injection.ldap;
+package com.h3xstream.findsecbugs.file;
 
 import com.h3xstream.findbugs.test.BaseDetectorTest;
 import com.h3xstream.findbugs.test.EasyBugReporter;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class JndiLdapInjectionSourceTest extends BaseDetectorTest {
+public class FileUploadFilenameDetectorTest extends BaseDetectorTest {
 
     @Test
-    public void detectLdapInjectionInQuery() throws Exception {
+    public void detectTaintedFilename() throws Exception {
         //Locate test code
         String[] files = {
-                getClassFilePath("testcode/ldap/JndiLdap")
+                getClassFilePath("testcode/FileUploadCommon"),
+                getClassFilePath("testcode/FileUploadWicket")
         };
 
         //Run the analysis
@@ -40,14 +40,16 @@ public class JndiLdapInjectionSourceTest extends BaseDetectorTest {
 
         verify(reporter).doReportBug(
                 bugDefinition()
-                        .bugType("LDAP_INJECTION")
-                        .inClass("JndiLdap")
-                        .atLine(45)
+                        .bugType("FILE_UPLOAD_FILENAME")
+                        .inClass("FileUploadWicket").inMethod("handleFile").atLine(16)
                         .build()
         );
-        
-        verify(reporter, times(1)).doReportBug(
-                bugDefinition().bugType("LDAP_INJECTION").build()
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("FILE_UPLOAD_FILENAME")
+                        .inClass("FileUploadCommon").inMethod("handleFile").atLine(17)
+                        .build()
         );
     }
 }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/file/PathTraversalDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/file/PathTraversalDetectorTest.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library.
  */
-package com.h3xstream.findsecbugs.endpoint;
+package com.h3xstream.findsecbugs.file;
 
 import com.h3xstream.findbugs.test.BaseDetectorTest;
 import com.h3xstream.findbugs.test.EasyBugReporter;
@@ -26,24 +26,33 @@ import java.util.Arrays;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-public class CookieDetectorTest extends BaseDetectorTest {
+public class PathTraversalDetectorTest extends BaseDetectorTest {
 
     @Test
-    public void detectCookieUsage() throws Exception {
+    public void detectPathTraversal() throws Exception {
         //Locate test code
         String[] files = {
-                getClassFilePath("testcode/CookieUsage")
+                getClassFilePath("testcode/PathTraversal")
         };
 
         //Run the analysis
         EasyBugReporter reporter = spy(new EasyBugReporter());
         analyze(files, reporter);
 
-        for (Integer line : Arrays.asList(15, 16, 17)) {
+        for (Integer line : Arrays.asList(10, 11, 13, 15, 17)) {
             verify(reporter).doReportBug(
                     bugDefinition()
-                            .bugType("COOKIE_USAGE")
-                            .inClass("CookieUsage").inMethod("doGet").atLine(15)
+                            .bugType("PATH_TRAVERSAL_IN")
+                            .inClass("PathTraversal").inMethod("main").atLine(line)
+                            .build()
+            );
+        }
+
+        for (Integer line : Arrays.asList(20, 21, 23, 24)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("PATH_TRAVERSAL_OUT")
+                            .inClass("PathTraversal").inMethod("main").atLine(line)
                             .build()
             );
         }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/injection/command/CommandInjectionDetectorAdvancedTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/injection/command/CommandInjectionDetectorAdvancedTest.java
@@ -1,0 +1,108 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.injection.command;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test some additional signatures for ProcessBuilder.
+ */
+public class CommandInjectionDetectorAdvancedTest extends BaseDetectorTest {
+    
+    @Test
+    public void avoidFalsePositive() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/command/CommandInjectionSafe"),
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new EasyBugReporter());
+        analyze(files, reporter);
+
+
+        //Assertions
+        verify(reporter,never()).doReportBug(
+                bugDefinition()
+                        .bugType("COMMAND_INJECTION")
+                        .inClass("CommandInjectionSafe")
+                        .build()
+        );
+
+    }
+
+    @Test
+    public void detectSuspicious() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/command/CommandInjectionSuspicious"),
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new EasyBugReporter());
+        analyze(files, reporter);
+
+
+        //Assertions
+        for(Integer line : Arrays.asList(11,13)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("COMMAND_INJECTION")
+                            .inClass("CommandInjectionSuspicious").inMethod("insecureConstructorArray").atLine(line)
+                            .build()
+            );
+        }
+
+        for(Integer line : Arrays.asList(20,23)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("COMMAND_INJECTION")
+                            .inClass("CommandInjectionSuspicious").inMethod("insecureConstructorList").atLine(line)
+                            .build()
+            );
+        }
+
+        for(Integer line : Arrays.asList(27,29)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("COMMAND_INJECTION")
+                            .inClass("CommandInjectionSuspicious").inMethod("insecureCommandMethodArray").atLine(line)
+                            .build()
+            );
+        }
+
+        for(Integer line : Arrays.asList(35,38)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("COMMAND_INJECTION")
+                            .inClass("CommandInjectionSuspicious").inMethod("insecureCommandMethodList").atLine(line)
+                            .build()
+            );
+        }
+
+    }
+
+}

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/injection/ldap/JndiLdapInjectionSourceAdditionalSignaturesTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/injection/ldap/JndiLdapInjectionSourceAdditionalSignaturesTest.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library.
  */
-package com.h3xstream.findsecbugs.crypto;
+package com.h3xstream.findsecbugs.injection.ldap;
 
 import com.h3xstream.findbugs.test.BaseDetectorTest;
 import com.h3xstream.findbugs.test.EasyBugReporter;
@@ -27,69 +27,60 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class DesUsageDetectorTest extends BaseDetectorTest {
+public class JndiLdapInjectionSourceAdditionalSignaturesTest extends BaseDetectorTest {
 
     @Test
-    public void detectDesCipher() throws Exception {
+    public void detectLdapInjectionInQuery() throws Exception {
         //Locate test code
         String[] files = {
-                getClassFilePath("testcode/crypto/BlockCipherList")
+                getClassFilePath("testcode/ldap/JndiLdapAdditionalSignature")
         };
 
         //Run the analysis
         EasyBugReporter reporter = spy(new EasyBugReporter());
         analyze(files, reporter);
 
-        //Assertions
-        for (Integer line : Arrays.asList(20, 21, 22, 23, 24, 25, 26, 27, 33, 34)) {
+        for(Integer line : Arrays.asList(39, 40, 41, 42, /**/ 44, 45, 46, 47, /**/ 49, 50, 51, 52, /**/ 54, 55, 56, 57)) {
             verify(reporter).doReportBug(
                     bugDefinition()
-                            .bugType("DES_USAGE")
-                            .inClass("BlockCipherList")
-                            .inMethod("main")
+                            .bugType("LDAP_INJECTION")
+                            .inClass("JndiLdapAdditionalSignature")
                             .atLine(line)
                             .build()
             );
         }
 
-        //Nothing more than the previous 10
-        verify(reporter, times(10)).doReportBug(
-                bugDefinition()
-                        .bugType("DES_USAGE")
-                        .inClass("BlockCipherList")
-                        .build()
+
+        verify(reporter, times(16)).doReportBug(
+                bugDefinition().bugType("LDAP_INJECTION").inMethod("moreLdapInjections").build()
         );
     }
 
     @Test
-    public void detectDesKeyGeneration() throws Exception {
+    public void detectLdapInjectionInQuerySunApi() throws Exception {
         //Locate test code
         String[] files = {
-                getClassFilePath("testcode/crypto/DesKeyGeneration")
+                getClassFilePath("testcode/ldap/JndiLdapAdditionalSignature")
         };
 
         //Run the analysis
         EasyBugReporter reporter = spy(new EasyBugReporter());
         analyze(files, reporter);
 
-        //Assertions
-        for (Integer line : Arrays.asList(11,12,13,14,15,16,17,18,19,20)) {
+        for(Integer line : Arrays.asList(83, 84, 85, 86, /**/ 88, 89, 90, 91)) {
             verify(reporter).doReportBug(
                     bugDefinition()
-                            .bugType("DES_USAGE")
-                            .inClass("DesKeyGeneration")
-                            .inMethod("weakDesKeyGenerator")
+                            .bugType("LDAP_INJECTION")
+                            .inClass("JndiLdapAdditionalSignature")
                             .atLine(line)
                             .build()
             );
         }
 
-        //Nothing more than the previous 4
-        verify(reporter, times(10)).doReportBug(
-                bugDefinition()
-                        .bugType("DES_USAGE")
-                        .inClass("DesKeyGeneration")
-                        .build()
+
+        verify(reporter, times(8)).doReportBug(
+                bugDefinition().bugType("LDAP_INJECTION").inMethod("ldapInjectionSunApi").build()
         );
     }
+
 }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/injection/sql/SpringJdbcOperationsAndTemplateTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/injection/sql/SpringJdbcOperationsAndTemplateTest.java
@@ -264,4 +264,62 @@ public class SpringJdbcOperationsAndTemplateTest extends BaseDetectorTest {
                         .build()
         );
     }
+
+    @Test
+    public void detectQueryInt() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/sqli/SpringJdbcOperations"),
+                getClassFilePath("testcode/sqli/SpringJdbcTemplate")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new EasyBugReporter());
+        analyze(files, reporter);
+
+        //Exact match of the number of vulnerability rise
+        verify(reporter, times(3)).doReportBug(
+                bugDefinition()
+                        .bugType("SQL_INJECTION_SPRING_JDBC")
+                        .inClass("SpringJdbcTemplate")
+                        .inMethod("queryForInt")
+                        .build()
+        );
+        verify(reporter, times(3)).doReportBug(
+                bugDefinition()
+                        .bugType("SQL_INJECTION_SPRING_JDBC")
+                        .inClass("SpringJdbcOperations")
+                        .inMethod("queryForInt")
+                        .build()
+        );
+    }
+
+    @Test
+    public void detectQueryLong() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/sqli/SpringJdbcOperations"),
+                getClassFilePath("testcode/sqli/SpringJdbcTemplate")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new EasyBugReporter());
+        analyze(files, reporter);
+
+        //Exact match of the number of vulnerability rise
+        verify(reporter, times(3)).doReportBug(
+                bugDefinition()
+                        .bugType("SQL_INJECTION_SPRING_JDBC")
+                        .inClass("SpringJdbcTemplate")
+                        .inMethod("queryForLong")
+                        .build()
+        );
+        verify(reporter, times(3)).doReportBug(
+                bugDefinition()
+                        .bugType("SQL_INJECTION_SPRING_JDBC")
+                        .inClass("SpringJdbcOperations")
+                        .inMethod("queryForLong")
+                        .build()
+        );
+    }
 }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/injection/stringbuilder/InjectionWithStringBuilderTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/injection/stringbuilder/InjectionWithStringBuilderTest.java
@@ -86,10 +86,9 @@ public class InjectionWithStringBuilderTest extends BaseDetectorTest {
         analyze(files, reporter);
 
         //Assertions
-        //Currently, the false positives are still rise but with Low priority. (To avoid hiding potential critical vulnerability.)
-        verify(reporter, never()).doReportBug(bugDefinition().bugType("SQL_INJECTION_JPA").withPriority("Medium").build());
-        verify(reporter,never()).doReportBug(bugDefinition().bugType("SQL_INJECTION_JDO").withPriority("Medium").build());
-        verify(reporter,never()).doReportBug(bugDefinition().bugType("SQL_INJECTION_HIBERNATE").withPriority("Medium").build());
+        verify(reporter, never()).doReportBug(bugDefinition().bugType("SQL_INJECTION_JPA").build());
+        verify(reporter,never()).doReportBug(bugDefinition().bugType("SQL_INJECTION_JDO").build());
+        verify(reporter,never()).doReportBug(bugDefinition().bugType("SQL_INJECTION_HIBERNATE").build());
     }
 
 }

--- a/plugin/src/test/java/testcode/UnvalidatedRedirectServlet.java
+++ b/plugin/src/test/java/testcode/UnvalidatedRedirectServlet.java
@@ -14,7 +14,7 @@ public class UnvalidatedRedirectServlet extends HttpServlet {
         unvalidatedRedirect1(resp, url);
     }
 
-    private void unvalidatedRedirect1(HttpServletResponse resp, String url) {
+    private void unvalidatedRedirect1(HttpServletResponse resp, String url) throws IOException {
         if (url != null) {
             resp.sendRedirect(url);
         }
@@ -28,7 +28,7 @@ public class UnvalidatedRedirectServlet extends HttpServlet {
 
     ///The following cases are safe for sure
 
-    public void falsePositiveRedirect1(HttpServletResponse resp) {
+    public void falsePositiveRedirect1(HttpServletResponse resp) throws IOException {
         String url = "/Home";
         if (url != null) {
             resp.sendRedirect(url);

--- a/plugin/src/test/java/testcode/command/CommandInjection.java
+++ b/plugin/src/test/java/testcode/command/CommandInjection.java
@@ -38,7 +38,7 @@ public abstract class CommandInjection {
         builder.insert(3, tainted).append("");
         builder.reverse();
         StringBuilder builder2 = new StringBuilder("xxx");
-        builder2.append(builder);
+        builder2.append("").append(builder);
         String safe = "yyy";
         String unsafe = safe.replace("y", builder2.toString());
         Runtime.getRuntime().exec(unsafe.toLowerCase().substring(1).intern());
@@ -51,7 +51,7 @@ public abstract class CommandInjection {
         builder.insert(3, hardcoded).append("");
         builder.reverse();
         StringBuilder builder2 = b ? new StringBuilder("xxx"): new StringBuilder(8);
-        builder2.append(builder);
+        builder2.append("").append(builder);
         String safe = "yyy";
         String unsafe = safe.replace("y", builder2.toString());
         Runtime.getRuntime().exec(unsafe.toLowerCase().substring(1).intern());
@@ -166,10 +166,10 @@ public abstract class CommandInjection {
     
     private String transferThroughList(String in, int index) {
         LinkedList<String> list = new LinkedList<String>();
-        //list.add(System.getenv(""));
-        //list.clear(); // works, but cause magical problems if combined with iterators
+        list.add(System.getenv("")); // taints the list
+        list.clear(); // makes the list safe again
         list.add(1, "xx");
-        list.addFirst(in);
+        list.addFirst(in); // can taint the list
         list.addLast("yy");
         list.push(in);
         return list.element() + list.get(index) + list.getFirst() + list.getLast()

--- a/plugin/src/test/java/testcode/command/CommandInjectionSafe.java
+++ b/plugin/src/test/java/testcode/command/CommandInjectionSafe.java
@@ -1,0 +1,45 @@
+package testcode.command;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class CommandInjectionSafe {
+
+    public void safeEmptyConstructor() {
+        new ProcessBuilder();
+    }
+
+    public void safeConstructorArray() {
+        new ProcessBuilder("ls","-la");
+        String[] cmd =new String[] {"ls","-la"};
+        new ProcessBuilder(cmd);
+    }
+
+    public void safeConstructorList() {
+        List<String> cmd1 = new ArrayList<String>();
+        cmd1.add("ls");
+        cmd1.add("-la");
+        new ProcessBuilder(cmd1);
+
+        List<String> cmd2 = Arrays.asList("ls","-la");
+        new ProcessBuilder(cmd2);
+    }
+
+    public void safeCommandMethodArray() {
+        new ProcessBuilder().command("ls", "-la");
+        String[] cmd = new String[] {"ls","-la"};
+        new ProcessBuilder().command(cmd);
+    }
+
+    public void safeCommandMethodList() {
+        List<String> cmd1 = new ArrayList<String>();
+        cmd1.add("ls");
+        cmd1.add("-la");
+        new ProcessBuilder().command(cmd1);
+
+        List<String> cmd2 = Arrays.asList("ls","-la");
+        new ProcessBuilder().command(cmd2);
+    }
+
+}

--- a/plugin/src/test/java/testcode/command/CommandInjectionSuspicious.java
+++ b/plugin/src/test/java/testcode/command/CommandInjectionSuspicious.java
@@ -1,0 +1,40 @@
+package testcode.command;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class CommandInjectionSuspicious {
+
+    public void insecureConstructorArray(String input) {
+        new ProcessBuilder("ls",input);
+        String[] cmd = new String[] {"ls",input};
+        new ProcessBuilder(cmd);
+
+    }
+
+    public void insecureConstructorList(String input) {
+        List<String> cmd1 = new ArrayList<String>();
+        cmd1.add(input);
+        new ProcessBuilder(cmd1);
+
+        List<String> cmd2 = Arrays.asList("ls", input);
+        new ProcessBuilder(cmd2);
+    }
+
+    public void insecureCommandMethodArray(String input) {
+        new ProcessBuilder().command("ls", input);
+        String[] cmd = new String[] {"ls",input};
+        new ProcessBuilder().command(cmd);
+    }
+
+    public void insecureCommandMethodList(String input) {
+        List<String> cmd1 = new ArrayList<String>();
+        cmd1.add(input);
+        new ProcessBuilder().command(cmd1);
+
+        List<String> cmd2 = Arrays.asList("ls",input);
+        new ProcessBuilder().command(cmd2);
+    }
+}

--- a/plugin/src/test/java/testcode/cookie/CookieUsage.java
+++ b/plugin/src/test/java/testcode/cookie/CookieUsage.java
@@ -1,4 +1,4 @@
-package testcode;
+package testcode.cookie;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;

--- a/plugin/src/test/java/testcode/cookie/InsecureCookieSamples.java
+++ b/plugin/src/test/java/testcode/cookie/InsecureCookieSamples.java
@@ -1,0 +1,66 @@
+package testcode.cookie;
+
+import javax.servlet.http.Cookie;
+
+public class InsecureCookieSamples {
+
+    private static final boolean CONST_TRUE = true;
+    private static final boolean CONST_FALSE = false;
+
+    void unsafeCookie1() {
+        Cookie newCookie = new Cookie("test1","1234");
+        newCookie.setSecure(false);
+    }
+
+    void unsafeCookie2() {
+        Cookie newCookie = new Cookie("test1","1234");
+        newCookie.setSecure(CONST_FALSE);
+    }
+
+    void unsafeCookie3(Cookie cookieOther) {
+        Cookie newCookie = new Cookie("test1","1234");
+        cookieOther.setSecure(true); //Unrelated
+    }
+
+    void unsafeCookie4() {
+        boolean unsafe = false;
+        Cookie newCookie = new Cookie("test1","1234");
+        newCookie.setSecure(unsafe);
+    }
+
+    void unsafeCookie5() {
+        Cookie newCookie = new Cookie("test1","1234");
+    }
+
+
+    void safeCookie1() {
+        Cookie cookie = new Cookie("test1","1234");
+        cookie.setSecure(true);
+    }
+
+    void safeCookie2() {
+        Cookie cookie = new Cookie("test1","1234");
+        cookie.setSecure(CONST_TRUE);
+    }
+
+    void safeCookie3() {
+        boolean safe = true;
+        Cookie cookie = new Cookie("test1","1234");
+        cookie.setSecure(safe);
+    }
+
+
+    void safeCookie4() {
+        boolean safe = true;
+        Cookie cookie = new Cookie("test1","1234");
+        cookie.setHttpOnly(false);
+        cookie.setSecure(safe);
+        cookie.setHttpOnly(false);
+    }
+
+    void safeCookie5(Cookie cookieOther) {
+        Cookie newCookie = new Cookie("test1","1234");
+        cookieOther.setSecure(false); //Unrelated
+    }
+
+}

--- a/plugin/src/test/java/testcode/crypto/BlockCipherList.java
+++ b/plugin/src/test/java/testcode/crypto/BlockCipherList.java
@@ -30,6 +30,8 @@ public class BlockCipherList {
         Cipher.getInstance("RSA/ECB/OAEPWithSHA-256AndMGF1Padding");
         Cipher.getInstance("RC2/ECB/PKCS5Padding");
         Cipher.getInstance("ARCFOUR/ECB/NOPADDING");
+        Cipher.getInstance("DES/CBC/NoPadding", "SunJCE");
+        Cipher.getInstance("DES");
         Cipher.getInstance("RSA"); //Just to test a cipher with a different format in the input
     }
 

--- a/plugin/src/test/java/testcode/crypto/DesKeyGeneration.java
+++ b/plugin/src/test/java/testcode/crypto/DesKeyGeneration.java
@@ -1,0 +1,31 @@
+package testcode.crypto;
+
+import javax.crypto.KeyGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Provider;
+
+public class DesKeyGeneration {
+
+    public static void weakDesKeyGenerator() throws NoSuchAlgorithmException, NoSuchProviderException {
+        KeyGenerator.getInstance("DES");
+        KeyGenerator.getInstance("des");
+        KeyGenerator.getInstance("DESede");
+        KeyGenerator.getInstance("DESEDE");
+        KeyGenerator.getInstance("DES",new DummyProvider());
+        KeyGenerator.getInstance("des",new DummyProvider());
+        KeyGenerator.getInstance("DESede",new DummyProvider());
+        KeyGenerator.getInstance("DES", "SUN");
+        KeyGenerator.getInstance("des", "SUN");
+        KeyGenerator.getInstance("DESede", "SUN");
+        KeyGenerator.getInstance("AES"); //OK!
+        KeyGenerator.getInstance("RSA"); //OK!
+    }
+
+    static class DummyProvider extends Provider {
+
+        protected DummyProvider() {
+            super("dummy", 1.0, "");
+        }
+    }
+}

--- a/plugin/src/test/java/testcode/crypto/WeakMessageDigestAdditionalSig.java
+++ b/plugin/src/test/java/testcode/crypto/WeakMessageDigestAdditionalSig.java
@@ -1,0 +1,32 @@
+package testcode.crypto;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Provider;
+
+public class WeakMessageDigestAdditionalSig {
+
+    public static void weakDigestMoreSig() throws NoSuchProviderException, NoSuchAlgorithmException {
+        MessageDigest.getInstance("SHA1", "SUN");
+        MessageDigest.getInstance("MD5", "SUN");
+        MessageDigest.getInstance("MD4", "SUN");
+        MessageDigest.getInstance("MD2", "SUN");
+        MessageDigest.getInstance("MD5");
+        MessageDigest.getInstance("MD4");
+        MessageDigest.getInstance("MD2");
+        MessageDigest.getInstance("SHA1", new DummyProvider());
+        MessageDigest.getInstance("MD5", new DummyProvider());
+        MessageDigest.getInstance("MD4", new DummyProvider());
+        MessageDigest.getInstance("MD2", new DummyProvider());
+        MessageDigest.getInstance("sha-384","SUN"); //OK!
+        MessageDigest.getInstance("SHA-512", "SUN"); //OK!
+    }
+
+    static class DummyProvider extends Provider {
+
+        protected DummyProvider() {
+            super("dummy", 1.0, "");
+        }
+    }
+}

--- a/plugin/src/test/java/testcode/ldap/JndiLdapAdditionalSignature.java
+++ b/plugin/src/test/java/testcode/ldap/JndiLdapAdditionalSignature.java
@@ -1,0 +1,94 @@
+package testcode.ldap;
+
+import com.sun.jndi.ldap.LdapCtx;
+
+import javax.naming.Context;
+import javax.naming.InvalidNameException;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.event.EventDirContext;
+import javax.naming.ldap.InitialLdapContext;
+import javax.naming.ldap.LdapContext;
+import javax.naming.ldap.LdapName;
+import java.util.Properties;
+
+public class JndiLdapAdditionalSignature {
+
+    public static void moreLdapInjections(String input) throws NamingException {
+        //Stub instances
+        Properties props = new Properties();
+        props.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        props.put(Context.PROVIDER_URL, "ldap://ldap.example.com");
+        props.put(Context.REFERRAL, "ignore");
+
+        SearchControls ctrls = new SearchControls();
+        ctrls.setReturningAttributes(new String[]{"givenName", "sn"});
+        ctrls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+
+        //Various context instance store in various type (class or interface)
+        DirContext         context1 = new InitialDirContext(props);
+        InitialDirContext  context2 = new InitialDirContext(props);
+        InitialLdapContext context3 = new InitialLdapContext();
+        LdapContext        context4 = new InitialLdapContext();
+
+        NamingEnumeration<SearchResult> answers;
+        answers = context1.search(new LdapName("dc=People,dc=example,dc=com"), "(uid=" + input + ")", ctrls);
+        answers = context1.search(new LdapName("dc=People,dc=example,dc=com"), "(uid=" + input + ")", new Object[0], ctrls);
+        answers = context1.search("dc=People,dc=example,dc=com", "(uid=" + input + ")", ctrls);
+        answers = context1.search("dc=People,dc=example,dc=com", "(uid=" + input + ")", new Object[0], ctrls);
+
+        answers = context2.search(new LdapName("dc=People,dc=example,dc=com"), "(uid=" + input + ")", ctrls);
+        answers = context2.search(new LdapName("dc=People,dc=example,dc=com"), "(uid=" + input + ")", new Object[0], ctrls);
+        answers = context2.search("dc=People,dc=example,dc=com", "(uid=" + input + ")", ctrls);
+        answers = context2.search("dc=People,dc=example,dc=com", "(uid=" + input + ")", new Object[0], ctrls);
+
+        answers = context3.search(new LdapName("dc=People,dc=example,dc=com"), "(uid=" + input + ")", ctrls);
+        answers = context3.search(new LdapName("dc=People,dc=example,dc=com"), "(uid=" + input + ")", new Object[0], ctrls);
+        answers = context3.search("dc=People,dc=example,dc=com", "(uid=" + input + ")", ctrls);
+        answers = context3.search("dc=People,dc=example,dc=com", "(uid=" + input + ")", new Object[0], ctrls);
+
+        answers = context4.search(new LdapName("dc=People,dc=example,dc=com"), "(uid=" + input + ")", ctrls);
+        answers = context4.search(new LdapName("dc=People,dc=example,dc=com"), "(uid=" + input + ")", new Object[0], ctrls);
+        answers = context4.search("dc=People,dc=example,dc=com", "(uid=" + input + ")", ctrls);
+        answers = context4.search("dc=People,dc=example,dc=com", "(uid=" + input + ")", new Object[0], ctrls);
+
+
+        //False positive
+        answers = context1.search(new LdapName("dc=People,dc=example,dc=com"), "(uid=bob)", ctrls);
+        answers = context1.search(new LdapName("dc=People,dc=example,dc=com"), "(uid=bob)", new Object[0], ctrls);
+        answers = context1.search("dc=People,dc=example,dc=com", "(uid=bob)", ctrls);
+        answers = context1.search("dc=People,dc=example,dc=com", "(uid=bob)", new Object[0], ctrls);
+    }
+
+    public void ldapInjectionSunApi(String input) throws NamingException {
+        //Stub instances
+        Properties props = new Properties();
+        props.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        props.put(Context.PROVIDER_URL, "ldap://ldap.example.com");
+        props.put(Context.REFERRAL, "ignore");
+
+        SearchControls ctrls = new SearchControls();
+        ctrls.setReturningAttributes(new String[]{"givenName", "sn"});
+        ctrls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+
+        //Two context instances mostly usable with sun specific API
+        LdapCtx            context5 = null;
+        EventDirContext    context6 = null; //LdapCtx is the only known class to implements to this interface
+
+        NamingEnumeration<SearchResult> answers;
+        answers = context5.search(new LdapName("dc=People,dc=example,dc=com"), "(uid=" + input + ")", ctrls);
+        answers = context5.search(new LdapName("dc=People,dc=example,dc=com"), "(uid=" + input + ")", new Object[0], ctrls);
+        answers = context5.search("dc=People,dc=example,dc=com", "(uid=" + input + ")", ctrls);
+        answers = context5.search("dc=People,dc=example,dc=com", "(uid=" + input + ")", new Object[0], ctrls);
+
+        answers = context6.search(new LdapName("dc=People,dc=example,dc=com"), "(uid=" + input + ")", ctrls);
+        answers = context6.search(new LdapName("dc=People,dc=example,dc=com"), "(uid=" + input + ")", new Object[0], ctrls);
+        answers = context6.search("dc=People,dc=example,dc=com", "(uid=" + input + ")", ctrls);
+        answers = context6.search("dc=People,dc=example,dc=com", "(uid=" + input + ")", new Object[0], ctrls);
+    }
+
+}

--- a/plugin/src/test/java/testcode/sqli/SpringJdbcOperations.java
+++ b/plugin/src/test/java/testcode/sqli/SpringJdbcOperations.java
@@ -108,6 +108,21 @@ public class SpringJdbcOperations {
         jdbcTemplate.queryForRowSet(sql, new Object[0], new int[]{Types.VARCHAR});
     }
 
+
+    public void queryForInt(String sql) throws DataAccessException {
+        //Query for int (3 signatures)
+        jdbcTemplate.queryForInt(sql);
+        jdbcTemplate.queryForInt(sql, new Object[0]);
+        jdbcTemplate.queryForInt(sql, new Object[0], new int[]{Types.VARCHAR});
+    }
+
+    public void queryForLong(String sql) throws DataAccessException {
+        //Query for long (3 signatures)
+        jdbcTemplate.queryForLong(sql);
+        jdbcTemplate.queryForLong(sql, new Object[0]);
+        jdbcTemplate.queryForLong(sql, new Object[0], new int[]{Types.VARCHAR});
+    }
+
     //Bunch of Mock classes
 
     public class StoredProcCall implements CallableStatementCreator {

--- a/plugin/src/test/java/testcode/sqli/SpringJdbcTemplate.java
+++ b/plugin/src/test/java/testcode/sqli/SpringJdbcTemplate.java
@@ -110,6 +110,20 @@ public class SpringJdbcTemplate {
     }
 
 
+    public void queryForInt(String sql) throws DataAccessException {
+        //Query for int (3 signatures)
+        jdbcTemplate.queryForInt(sql);
+        jdbcTemplate.queryForInt(sql, new Object[0]);
+        jdbcTemplate.queryForInt(sql, new Object[0], new int[]{Types.VARCHAR});
+    }
+
+    public void queryForLong(String sql) throws DataAccessException {
+        //Query for long (3 signatures)
+        jdbcTemplate.queryForLong(sql);
+        jdbcTemplate.queryForLong(sql, new Object[0]);
+        jdbcTemplate.queryForLong(sql, new Object[0], new int[]{Types.VARCHAR});
+    }
+
     //Bunch of Mock classes
 
     public class StoredProcCall implements CallableStatementCreator {

--- a/plugin/test-dependencies.xml
+++ b/plugin/test-dependencies.xml
@@ -51,7 +51,18 @@
                 <groupId>org.apache.tapestry</groupId>
                 <artifactId>tapestry-json</artifactId>
             </exclusion>
+            <exclusion>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+            </exclusion>
         </exclusions>
+    </dependency>
+
+
+    <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>1.3</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Analysis no longer relies on direct modifications of `Taint` instances in `TaintFrame` and the code is refactored to be more robust and clear. This pull request should fix issues #80, #82, #83, #84, #85 and #90. 

There is a change in constructor summaries - now there are two mutable stack indices, since new instances are duplicated before calling a constructor.