### PR TITLE
Response splitting, hash functions and messages

### DIFF
--- a/plugin-deps/src/main/java/javax/servlet/http/HttpServletResponse.java
+++ b/plugin-deps/src/main/java/javax/servlet/http/HttpServletResponse.java
@@ -8,6 +8,8 @@ public interface HttpServletResponse extends ServletResponse {
     void addCookie(Cookie cookie);
 
     void addHeader(String header, String value);
+    
+    void setHeader(String header, String value);
 
     void sendRedirect(String url) throws IOException;
 }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/HttpResponseSplittingDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/HttpResponseSplittingDetector.java
@@ -1,0 +1,34 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs;
+
+import com.h3xstream.findsecbugs.injection.ConfiguredBasicInjectionDetector;
+import edu.umd.cs.findbugs.BugReporter;
+
+/**
+ * Detects HTTP Response splitting weakness
+ * 
+ * @author David Formanek (Y Soft Corporation, a.s.)
+ */
+public class HttpResponseSplittingDetector extends ConfiguredBasicInjectionDetector {
+
+    public HttpResponseSplittingDetector(BugReporter bugReporter) {
+        super(bugReporter);
+        loadConfiguredSinks("response-splitting.txt", "HTTP_RESPONSE_SPLITTING");
+    }
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/WeakMessageDigestDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/WeakMessageDigestDetector.java
@@ -25,14 +25,14 @@ import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 import org.apache.bcel.Constants;
 
 /**
- * Identify the use MD2 and MD5 hashing function and recommend the
- * use of SHA functions.
+ * Identifies the use of MD2, MD5 and SHA1 hash function and recommends the
+ * use of modern functions.
  */
 public class WeakMessageDigestDetector extends OpcodeStackDetector {
 
     private static final String WEAK_MESSAGE_DIGEST_TYPE = "WEAK_MESSAGE_DIGEST";
 
-    private BugReporter bugReporter;
+    private final BugReporter bugReporter;
 
     public WeakMessageDigestDetector(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
@@ -40,19 +40,22 @@ public class WeakMessageDigestDetector extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
-        //printOpCode(seen);
-        if (seen == Constants.INVOKESTATIC && getClassConstantOperand().equals("java/security/MessageDigest") &&
-                getNameConstantOperand().equals("getInstance")) {
-
-            OpcodeStack.Item item;
-            if(getSigConstantOperand().equals("(Ljava/lang/String;)Ljava/security/MessageDigest;")) {
-                //Extract the value being push..
+        if (seen != Constants.INVOKESTATIC) {
+            return;
+        }
+        String className = getClassConstantOperand();
+        String methodName = getNameConstantOperand();
+        if (className.equals("java/security/MessageDigest") && methodName.equals("getInstance")) {
+            final OpcodeStack.Item item;
+            String methodSig = getSigConstantOperand();
+            if (methodSig.equals("(Ljava/lang/String;)Ljava/security/MessageDigest;")) {
+                //Extract the value being pushed..
                 item = stack.getStackItem(0);
             }
-            else if(getSigConstantOperand().equals("(Ljava/lang/String;Ljava/lang/String;)Ljava/security/MessageDigest;")) {
+            else if (methodSig.equals("(Ljava/lang/String;Ljava/lang/String;)Ljava/security/MessageDigest;")) {
                 item = stack.getStackItem(1);
             }
-            else if(getSigConstantOperand().equals("(Ljava/lang/String;Ljava/security/Provider;)Ljava/security/MessageDigest;")) {
+            else if (methodSig.equals("(Ljava/lang/String;Ljava/security/Provider;)Ljava/security/MessageDigest;")) {
                 item = stack.getStackItem(1);
             }
             else {
@@ -60,49 +63,46 @@ public class WeakMessageDigestDetector extends OpcodeStackDetector {
             }
             String algorithm = (String) item.getConstant(); //Null if the value passed isn't constant
             analyzeHashingFunction(algorithm);
-        }
-
-        if (seen == Constants.INVOKESTATIC && //
-                getClassConstantOperand().equals("org/apache/commons/codec/digest/DigestUtils")) {
-            if(getNameConstantOperand().equals("getMd2Digest") || //
-                    getNameConstantOperand().equals("md2Hex")) {
+        } else if (className.equals("org/apache/commons/codec/digest/DigestUtils")) {
+            if (methodName.equals("getMd2Digest")
+                    || methodName.equals("md2")
+                    || methodName.equals("md2Hex")) {
                 analyzeHashingFunction("md2");
             }
-
-            if(getNameConstantOperand().equals("getMd5Digest") || //
-                    getNameConstantOperand().equals("md5Hex")) {
+            if(methodName.equals("getMd5Digest")
+                    || methodName.equals("md5")
+                    || methodName.equals("md5Hex")) {
                 analyzeHashingFunction("md5");
             }
-
-            if(getNameConstantOperand().equals("getSha1Digest") || //
-                    getNameConstantOperand().equals("getShaDigest") ||
-                    getNameConstantOperand().equals("sha1Hex")) {
+            if(methodName.equals("getSha1Digest")
+                    || methodName.equals("getShaDigest")
+                    || methodName.equals("sha1")
+                    || methodName.equals("sha")
+                    || methodName.equals("sha1Hex")
+                    || methodName.equals("shaHex")) {
                 analyzeHashingFunction("sha1");
             }
-
-            if(getNameConstantOperand().equals("getDigest")) {
-                //Extract the value being push..
+            if(methodName.equals("getDigest")) {
+                //Extract the value being pushed..
                 OpcodeStack.Item top = stack.getStackItem(0);
                 String algorithm = (String) top.getConstant(); //Null if the value passed isn't constant
-
                 analyzeHashingFunction(algorithm);
             }
         }
     }
 
     private void analyzeHashingFunction(String algorithm) {
-        if(algorithm == null) return;
-
+        if (algorithm == null) {
+            return;
+        }
         algorithm = algorithm.toUpperCase();
-
         if ("MD2".equals(algorithm) || "MD4".equals(algorithm) || "MD5".equals(algorithm)) {
-            bugReporter.reportBug(new BugInstance(this, WEAK_MESSAGE_DIGEST_TYPE, Priorities.NORMAL_PRIORITY) //
+            bugReporter.reportBug(new BugInstance(this, WEAK_MESSAGE_DIGEST_TYPE, Priorities.HIGH_PRIORITY) //
                     .addClass(this).addMethod(this).addSourceLine(this) //
                     .addString(algorithm));
         }
-
         if ("SHA1".equals(algorithm)) { //Lower priority for SHA-1
-            bugReporter.reportBug(new BugInstance(this, WEAK_MESSAGE_DIGEST_TYPE, Priorities.LOW_PRIORITY) //
+            bugReporter.reportBug(new BugInstance(this, WEAK_MESSAGE_DIGEST_TYPE, Priorities.NORMAL_PRIORITY) //
                     .addClass(this).addMethod(this).addSourceLine(this) //
                     .addString(algorithm));
         }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/injection/redirect/RedirectionSource.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/injection/redirect/RedirectionSource.java
@@ -40,14 +40,19 @@ public class RedirectionSource implements InjectionSource {
 
             if (className.equals("javax.servlet.http.HttpServletResponse")) {
                 if (methodName.equals("sendRedirect")) {
-                    return new InjectionPoint(new int[]{0},UNVALIDATED_REDIRECT_TYPE);
+                    InjectionPoint ip = new InjectionPoint(new int[]{0}, UNVALIDATED_REDIRECT_TYPE);
+                    ip.setInjectableMethod("HttpServletResponse.sendRedirect(...)");
+                    return ip;
+                    
                 } else if (methodName.equals("addHeader")) {
 
                     LDC ldc = ByteCode.getPrevInstruction(insHandle, LDC.class);
                     if (ldc != null) {
                         Object value = ldc.getValue(cpg);
                         if ("Location".equals(value)) {
-                            return new InjectionPoint(new int[]{0},UNVALIDATED_REDIRECT_TYPE);
+                            InjectionPoint ip = new InjectionPoint(new int[]{0},UNVALIDATED_REDIRECT_TYPE);
+                            ip.setInjectableMethod("HttpServletResponse.addHeader(\"Location\", ...)");
+                            return ip;
                         }
                     }
 

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/jsp/JstlOutDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/jsp/JstlOutDetector.java
@@ -27,18 +27,17 @@ import edu.umd.cs.findbugs.ba.CFGBuilderException;
 import edu.umd.cs.findbugs.ba.ClassContext;
 import edu.umd.cs.findbugs.ba.DataflowAnalysisException;
 import edu.umd.cs.findbugs.ba.Location;
+import java.util.Iterator;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.INVOKEVIRTUAL;
 import org.apache.bcel.generic.Instruction;
 
-import java.util.Iterator;
-
 public class JstlOutDetector implements Detector {
     private static final String JSP_JSTL_OUT = "JSP_JSTL_OUT";
 
-    private BugReporter bugReporter;
+    private final BugReporter bugReporter;
 
     public JstlOutDetector(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
@@ -47,9 +46,7 @@ public class JstlOutDetector implements Detector {
     @Override
     public void visitClassContext(ClassContext classContext) {
         JavaClass javaClass = classContext.getJavaClass();
-
         for (Method m : javaClass.getMethods()) {
-
             try {
                 analyzeMethod(m, classContext);
             } catch (CFGBuilderException e) {
@@ -71,7 +68,7 @@ public class JstlOutDetector implements Detector {
             Location location = i.next();
 
             Instruction inst = location.getHandle().getInstruction();
-            ByteCode.printOpCode(inst, cpg);
+            //ByteCode.printOpCode(inst, cpg);
 
 //        JspSpringEvalDetector: [0047]  aload   4
 //        JspSpringEvalDetector: [0049]  iconst_1

--- a/plugin/src/main/resources/injection-sinks/response-splitting.txt
+++ b/plugin/src/main/resources/injection-sinks/response-splitting.txt
@@ -1,0 +1,7 @@
+javax/servlet/http/Cookie.<init>(Ljava/lang/String;Ljava/lang/String;)V:0,1
+javax/servlet/http/Cookie.setValue(Ljava/lang/String;)V:0
+
+javax/servlet/http/HttpServletResponse.addHeader(Ljava/lang/String;Ljava/lang/String;)V:0,1
+javax/servlet/http/HttpServletResponse.setHeader(Ljava/lang/String;Ljava/lang/String;)V:0,1
+javax/servlet/http/HttpServletResponseWrapper.addHeader(Ljava/lang/String;Ljava/lang/String;)V:0,1
+javax/servlet/http/HttpServletResponseWrapper.setHeader(Ljava/lang/String;Ljava/lang/String;)V:0,1

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -64,6 +64,7 @@
     <Detector class="com.h3xstream.findsecbugs.crypto.CipherWithNoIntegrityDetector" reports="ECB_MODE,PADDING_ORACLE,CIPHER_INTEGRITY"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.EsapiEncryptorDetector" reports="ESAPI_ENCRYPTOR"/>
     <Detector class="com.h3xstream.findsecbugs.injection.script.ScriptInjectionDetector" reports="SCRIPT_ENGINE_INJECTION,SPEL_INJECTION"/>
+    <Detector class="com.h3xstream.findsecbugs.HttpResponseSplittingDetector" reports="HTTP_RESPONSE_SPLITTING"/>
     <Detector class="com.h3xstream.findsecbugs.android.ExternalFileAccessDetector" reports="ANDROID_EXTERNAL_FILE_ACCESS"/>
     <Detector class="com.h3xstream.findsecbugs.android.BroadcastDetector" reports="ANDROID_BROADCAST"/>
     <Detector class="com.h3xstream.findsecbugs.android.WorldWritableDetector" reports="ANDROID_WORLD_WRITABLE"/>
@@ -135,6 +136,7 @@
     <BugPattern type="ESAPI_ENCRYPTOR" abbrev="ESAPIENC" category="SECURITY"/>
     <BugPattern type="SCRIPT_ENGINE_INJECTION" abbrev="SCRIPTE" category="SECURITY" cweid="94"/>
     <BugPattern type="SPEL_INJECTION" abbrev="SPELI" category="SECURITY" cweid="94"/>
+    <BugPattern type="HTTP_RESPONSE_SPLITTING" abbrev="SECHRS" category="SECURITY" cweid="113"/>
     <BugPattern type="ANDROID_EXTERNAL_FILE_ACCESS" abbrev="SECEFA" category="SECURITY"/>
     <BugPattern type="ANDROID_BROADCAST" abbrev="SECBROAD" category="SECURITY"/>
     <BugPattern type="ANDROID_WORLD_WRITABLE" abbrev="SECWW" category="SECURITY"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -1473,6 +1473,44 @@ public void parseExpressionInterface(Person personObj,String property) {
     <BugCode abbrev="SPELI">Spring Expression Language Injection</BugCode>
 
 
+    <!-- HTTP Response Splitting -->
+    <Detector class="com.h3xstream.findsecbugs.HttpResponseSplittingDetector">
+        <Details>Searches for HTTP Response splitting weakness</Details>
+    </Detector>
+
+    <BugPattern type="HTTP_RESPONSE_SPLITTING">
+        <ShortDescription>Potential HTTP Response Splitting</ShortDescription>
+        <LongDescription>{3} is used to possibly include CRLF characters into HTTP headers</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+    When an HTTP request contains unexpected CR and LF characters, the server may respond with an output stream
+    that is interpreted as two different HTTP responses (instead of one).
+    An attacker can control the second response and mount attacks such as cross-site scripting and cache poisoning attacks.
+    According to OWASP, the issue has been fixed in virtually all modern Java EE application servers, but it is still better to validate the input.
+    If you are concerned about this risk, you should test on the platform of concern to see
+    if the underlying platform allows for CR or LF characters to be injected into headers.
+</p>
+<p><b>Code at risk:</b></p>
+<p>
+<pre>String author = request.getParameter(AUTHOR_PARAMETER);
+// ...
+Cookie cookie = new Cookie("author", author);
+response.addCookie(cookie);</pre>
+</p>
+<br/>
+<p>
+    <b>References</b><br/>
+    <a href="https://www.owasp.org/index.php/HTTP_Response_Splitting">OWASP: HTTP Response Splitting</a><br/>
+    <a href="http://cwe.mitre.org/data/definitions/113.html">CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')</a><br/>
+</p>
+
+]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECHRS">HTTP Response Splitting</BugCode>
+
+
     <!-- Bad Hexa -->
     <Detector class="com.h3xstream.findsecbugs.crypto.BadHexadecimalConversionDetector">
         <Details>Identify Bad hexadecimal concatenation</Details>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -16,8 +16,8 @@
     </Detector>
 
     <BugPattern type="PREDICTABLE_RANDOM">
-        <ShortDescription>Predictable Pseudo Random Number Generator</ShortDescription>
-        <LongDescription>Use of {3} is predictable.</LongDescription>
+        <ShortDescription>Predictable pseudorandom number generator</ShortDescription>
+        <LongDescription>The use of {3} is predictable</LongDescription>
         <Details>
             <![CDATA[
 <p>The use of a predictable random value can lead to vulnerabilities when used in certain security critical contexts. For example, when the value is used as:</p>
@@ -69,8 +69,8 @@ String generateSecretToken() {
     </Detector>
 
     <BugPattern type="SERVLET_PARAMETER">
-        <ShortDescription>Untrusted Servlet Parameter</ShortDescription>
-        <LongDescription>The method {3} returns a String value that is controlled by the client.</LongDescription>
+        <ShortDescription>Untrusted servlet parameter</ShortDescription>
+        <LongDescription>The method {3} returns a String value that is controlled by the client</LongDescription>
         <Details>
             <![CDATA[
 <p>The Servlet can read GET and POST parameters from various methods. The value obtained should be considered unsafe.
@@ -95,8 +95,8 @@ You may need to validate or sanitize those values before passing them to sensiti
 
 
     <BugPattern type="SERVLET_CONTENT_TYPE">
-        <ShortDescription>Untrusted Content-Type Header</ShortDescription>
-        <LongDescription>The HTTP header Content-Type can be controlled by the client.</LongDescription>
+        <ShortDescription>Untrusted Content-Type header</ShortDescription>
+        <LongDescription>The HTTP header Content-Type can be controlled by the client</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -114,8 +114,8 @@ The HTTP header Content-Type can be controlled by the client. As such, its value
 
 
     <BugPattern type="SERVLET_SERVER_NAME">
-        <ShortDescription>Untrusted Hostname Header</ShortDescription>
-        <LongDescription>The hostname received can often be controlled by the client.</LongDescription>
+        <ShortDescription>Untrusted Hostname header</ShortDescription>
+        <LongDescription>The hostname received can often be controlled by the client</LongDescription>
         <Details>
             <![CDATA[
 <p>The hostname header can be controlled by the client. As such, its value should not be used in any security critical decisions. 
@@ -142,8 +142,8 @@ decisions you make with respect to a request.
 
 
     <BugPattern type="SERVLET_SESSION_ID">
-        <ShortDescription>Untrusted Session Cookie Value</ShortDescription>
-        <LongDescription>Direct access to Session ID should be avoided.</LongDescription>
+        <ShortDescription>Untrusted session cookie value</ShortDescription>
+        <LongDescription>Direct access to Session ID should be avoided</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -178,8 +178,8 @@ valid active session IDs, allowing an insider to hijack any sessions whose IDs h
 
 
     <BugPattern type="SERVLET_QUERY_STRING">
-        <ShortDescription>Untrusted Query String</ShortDescription>
-        <LongDescription>The query string can be any value.</LongDescription>
+        <ShortDescription>Untrusted query string</ShortDescription>
+        <LongDescription>The query string can be any value</LongDescription>
         <Details>
             <![CDATA[
 <p>The query string is the concatenation of the GET parameter names and values. Parameters other than those intended can
@@ -201,8 +201,8 @@ You may need to validate or sanitize anything pulled from the query string befor
 
 
     <BugPattern type="SERVLET_HEADER">
-        <ShortDescription>HTTP Headers Untrusted</ShortDescription>
-        <LongDescription>Request header can easily be altered by the client.</LongDescription>
+        <ShortDescription>HTTP headers untrusted</ShortDescription>
+        <LongDescription>Request header can easily be altered by the client</LongDescription>
         <Details>
             <![CDATA[
 <p>Request headers can easily be altered by the requesting user. In general, no assumption should be made that 
@@ -220,8 +220,8 @@ not trust this value in any security decisions you make with respect to a reques
 
 
     <BugPattern type="SERVLET_HEADER_REFERER">
-        <ShortDescription>Untrusted Referer Header</ShortDescription>
-        <LongDescription>The header "Referer" can easily be spoofed by the client.</LongDescription>
+        <ShortDescription>Untrusted Referer header</ShortDescription>
+        <LongDescription>The header "Referer" can easily be spoofed by the client</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -250,8 +250,8 @@ Recommendations:
 
 
     <BugPattern type="SERVLET_HEADER_USER_AGENT">
-        <ShortDescription>Untrusted User-Agent Header</ShortDescription>
-        <LongDescription>The header "User-Agent" can easily be spoofed by the client.</LongDescription>
+        <ShortDescription>Untrusted User-Agent header</ShortDescription>
+        <LongDescription>The header "User-Agent" can easily be spoofed by the client</LongDescription>
         <Details>
             <![CDATA[
 <p>The header "User-Agent" can easily be spoofed by the client. Adopting different behaviors based on the User-Agent (for
@@ -273,8 +273,8 @@ crawler UA) is not recommended.</p>
     </Detector>
 
     <BugPattern type="COOKIE_USAGE">
-        <ShortDescription>Potentially Sensitive Data in Cookie</ShortDescription>
-        <LongDescription>Sensitive data may be stored by the application in a cookie.</LongDescription>
+        <ShortDescription>Potentially sensitive data in a cookie</ShortDescription>
+        <LongDescription>Sensitive data may be stored by the application in a cookie</LongDescription>
         <Details>
             <![CDATA[
 <p>The information stored in a custom cookie should not be sensitive or related to the session. In most cases, sensitive data should only be stored in session
@@ -297,8 +297,8 @@ and referenced by the user's session cookie. See HttpSession (HttpServletRequest
     </Detector>
 
     <BugPattern type="PATH_TRAVERSAL_IN">
-        <ShortDescription>Potential Path Traversal (File Read)</ShortDescription>
-        <LongDescription>Method {3} reads a file whose location is specified by user input.</LongDescription>
+        <ShortDescription>Potential Path Traversal (file read)</ShortDescription>
+        <LongDescription>{3} reads a file whose location might be specified by user input</LongDescription>
         <Details>
             <![CDATA[
 <p>A file is opened to read its content. The filename comes from an <b>input</b> parameter. 
@@ -316,12 +316,12 @@ by the user. If that is the case, the reported instance is a false positive.</p>
 ]]>
         </Details>
     </BugPattern>
-    <BugCode abbrev="SECPTI">Potential Path Traversal (File Read)</BugCode>
+    <BugCode abbrev="SECPTI">Potential Path Traversal (file read)</BugCode>
 
 
     <BugPattern type="PATH_TRAVERSAL_OUT">
-        <ShortDescription>Potential Path Traversal (File Write)</ShortDescription>
-        <LongDescription>Method {3} writes to a file whose location is specified by user input.</LongDescription>
+        <ShortDescription>Potential Path Traversal (file write)</ShortDescription>
+        <LongDescription>{3} writes to a file whose location might be specified by user input</LongDescription>
         <Details>
             <![CDATA[
 <p>A file is opened to write to its contents. The filename comes from an <b>input</b> parameter. 
@@ -349,7 +349,7 @@ by the user. If that is the case, the reported instance is a false positive.</p>
 
     <BugPattern type="COMMAND_INJECTION">
         <ShortDescription>Potential Command Injection</ShortDescription>
-        <LongDescription>{3} is used to executed system commands.</LongDescription>
+        <LongDescription>This usage of {3} can be vulnerable to Command Injection</LongDescription>
         <Details>
             <![CDATA[
 <p>The highlighted API is used to execute a system command. If unfiltered input is passed to this API, it can lead to arbitrary command execution.</p>
@@ -372,8 +372,8 @@ by the user. If that is the case, the reported instance is a false positive.</p>
     </Detector>
 
     <BugPattern type="WEAK_FILENAMEUTILS">
-        <ShortDescription>FilenameUtils Not Filtering Null Bytes</ShortDescription>
-        <LongDescription>FilenameUtils.{3} doesn't filter NULL bytes.</LongDescription>
+        <ShortDescription>FilenameUtils not filtering null bytes</ShortDescription>
+        <LongDescription>FilenameUtils.{3} doesn't filter null bytes</LongDescription>
         <Details>
             <![CDATA[
 <p>Some FilenameUtils' methods don't filter NULL bytes (<code>0x00</code>).</p>
@@ -407,8 +407,8 @@ that looks at the end of the filename (e.g., endswith ".log") to make sure its a
     </Detector>
 
     <BugPattern type="WEAK_TRUST_MANAGER">
-        <ShortDescription>TrustManager Implementation Empty</ShortDescription>
-        <LongDescription>The implementation of TrustManager is vulnerable to a MITM attack.</LongDescription>
+        <ShortDescription>TrustManager implementation empty</ShortDescription>
+        <LongDescription>This implementation of TrustManager is vulnerable to a MITM attack</LongDescription>
         <Details>
             <![CDATA[
 <p>Empty TrustManager implementations are often used to connect easily to a host that is not signed by a root
@@ -440,7 +440,7 @@ Detailed information for a proper implementation is at:
     </Detector>
 
     <BugPattern type="JAXWS_ENDPOINT">
-        <ShortDescription>Found JAX-WS SOAP Endpoint</ShortDescription>
+        <ShortDescription>Found JAX-WS SOAP endpoint</ShortDescription>
         <LongDescription>{0}.{1} is a SOAP Web Service endpoint</LongDescription>
         <Details>
             <![CDATA[
@@ -472,7 +472,7 @@ Detailed information for a proper implementation is at:
     </Detector>
 
     <BugPattern type="JAXRS_ENDPOINT">
-        <ShortDescription>Found JAX-RS REST Endpoint</ShortDescription>
+        <ShortDescription>Found JAX-RS REST endpoint</ShortDescription>
         <LongDescription>{0}.{1} is a REST Web Service endpoint</LongDescription>
         <Details>
             <![CDATA[
@@ -509,8 +509,8 @@ Detailed information for a proper implementation is at:
     </Detector>
 
     <BugPattern type="TAPESTRY_ENDPOINT">
-        <ShortDescription>Found Tapestry Page</ShortDescription>
-        <LongDescription>{0} is a Tapestry Page</LongDescription>
+        <ShortDescription>Found Tapestry page</ShortDescription>
+        <LongDescription>{0} is a Tapestry page</LongDescription>
         <Details>
             <![CDATA[
 <p>A Tapestry endpoint was discovered at application startup. Tapestry apps are structured with a backing Java class and a corresponding 
@@ -552,7 +552,7 @@ mapped in this way are properly validated before they are used.</p>
     </Detector>
 
     <BugPattern type="WICKET_ENDPOINT">
-        <ShortDescription>Found Wicket Page</ShortDescription>
+        <ShortDescription>Found Wicket WebPage</ShortDescription>
         <LongDescription>{0} is a Wicket WebPage</LongDescription>
         <Details>
             <![CDATA[
@@ -578,8 +578,8 @@ mapped in this way are properly validated before they are used.</p>
     </Detector>
 
     <BugPattern type="WEAK_MESSAGE_DIGEST">
-        <ShortDescription>MessageDigest Is Weak</ShortDescription>
-        <LongDescription>{3} is not a recommended MessageDigest/Hashing Algorithm</LongDescription>
+        <ShortDescription>Message digest is weak</ShortDescription>
+        <LongDescription>{3} is not a recommended cryptographic hash function</LongDescription>
         <Details>
             <![CDATA[
 <p>The algorithm used is not a recommended MessageDigest.</p>
@@ -604,8 +604,8 @@ mapped in this way are properly validated before they are used.</p>
     </Detector>
 
     <BugPattern type="CUSTOM_MESSAGE_DIGEST">
-        <ShortDescription>MessageDigest Is Custom</ShortDescription>
-        <LongDescription>{0} is a custom MessageDigest</LongDescription>
+        <ShortDescription>Message digest is custom</ShortDescription>
+        <LongDescription>{0} is a custom cryptographic hash function implementation</LongDescription>
         <Details>
             <![CDATA[
 <p>Implementing a custom MessageDigest is error-prone.</p>
@@ -647,7 +647,7 @@ sha256Digest.update(password.getBytes());</pre>
     </Detector>
 
     <BugPattern type="FILE_UPLOAD_FILENAME">
-        <ShortDescription>Tainted Filename Read</ShortDescription>
+        <ShortDescription>Tainted filename read</ShortDescription>
         <LongDescription>The filename read can be tampered with by the client</LongDescription>
         <Details>
             <![CDATA[
@@ -719,8 +719,8 @@ regex meant, this new regex can be evaluated quickly, and is not subject to ReDO
     </Detector>
 
     <BugPattern type="XXE_SAXPARSER">
-        <ShortDescription>XML Parsing Vulnerable to XXE (SAXParser)</ShortDescription>
-        <LongDescription>The usage of {3} is vulnerable to XML External Entity attacks</LongDescription>
+        <ShortDescription>XML parsing vulnerable to XXE (SAXParser)</ShortDescription>
+        <LongDescription>The use of {3} is vulnerable to XML External Entity attacks</LongDescription>
         <Details>
             <![CDATA[
 <!--XXE_GENERIC_START-->
@@ -803,8 +803,8 @@ parser.parse(inputStream, customHandler);</pre>
     <BugCode abbrev="SECXXESAX">XXE Vulnerability using SAXParser</BugCode>
 
     <BugPattern type="XXE_XMLREADER">
-        <ShortDescription>XML Parsing Vulnerable to XXE (XMLReader)</ShortDescription>
-        <LongDescription>The usage of {3} is vulnerable to XML External Entity attacks</LongDescription>
+        <ShortDescription>XML parsing vulnerable to XXE (XMLReader)</ShortDescription>
+        <LongDescription>The use of {3} is vulnerable to XML External Entity attacks</LongDescription>
         <Details>
             <![CDATA[
 <!--XXE_GENERIC_START-->
@@ -887,8 +887,8 @@ reader.parse(new InputSource(inputStream));</pre>
     <BugCode abbrev="SECXXEREAD">XXE Vulnerability using XMLReader</BugCode>
 
     <BugPattern type="XXE_DOCUMENT">
-        <ShortDescription>XML Parsing Vulnerable to XXE (DocumentBuilder)</ShortDescription>
-        <LongDescription>The usage of {3} is vulnerable to XML External Entity attacks</LongDescription>
+        <ShortDescription>XML parsing vulnerable to XXE (DocumentBuilder)</ShortDescription>
+        <LongDescription>The use of {3} is vulnerable to XML External Entity attacks</LongDescription>
         <Details>
             <![CDATA[
 <!--XXE_GENERIC_START-->
@@ -977,7 +977,7 @@ Document doc = db.parse(input);</pre>
     
     <BugPattern type="XPATH_INJECTION">
         <ShortDescription>Potential XPath Injection</ShortDescription>
-        <LongDescription>The use of {3} is vulnerable to XPath injection</LongDescription>
+        <LongDescription>This use of {3} can be vulnerable to XPath Injection</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -1001,12 +1001,12 @@ could be exposed. This could allow an attacker to access unauthorized data or ma
 
     <!-- Struts1 -->
     <Detector class="com.h3xstream.findsecbugs.endpoint.Struts1EndpointDetector">
-        <Details>Identify Struts 1 endpoint (also called Action)</Details>
+        <Details>Identifies Struts 1 endpoint (also called Action)</Details>
     </Detector>
 
     <BugPattern type="STRUTS1_ENDPOINT">
-        <ShortDescription>Found Struts 1 Action</ShortDescription>
-        <LongDescription>{0} is a Struts 1 Endpoint</LongDescription>
+        <ShortDescription>Found Struts 1 endpoint</ShortDescription>
+        <LongDescription>{0} is a Struts 1 endpoint (Action)</LongDescription>
         <Details>
             <![CDATA[
 <p>This class is a Struts 1 Action.</p>
@@ -1019,11 +1019,11 @@ The use of these parameters should be reviewed to make sure they are used safely
 
     <!-- Struts2 -->
     <Detector class="com.h3xstream.findsecbugs.endpoint.Struts2EndpointDetector">
-        <Details>Identify Struts 2 Endpoint</Details>
+        <Details>Identifies Struts 2 Endpoint</Details>
     </Detector>
     <BugPattern type="STRUTS2_ENDPOINT">
-        <ShortDescription>Found Struts 2 Endpoint</ShortDescription>
-        <LongDescription>{0} is a Struts 2 Endpoint</LongDescription>
+        <ShortDescription>Found Struts 2 endpoint</ShortDescription>
+        <LongDescription>{0} is a Struts 2 endpoint</LongDescription>
         <Details>
             <![CDATA[
 <p>In Struts 2, the endpoints are Plain Old Java Objects (POJOs) which means no Interface/Class needs to be implemented/extended.</p>
@@ -1039,11 +1039,11 @@ such a setter. The use of these parameters should be reviewed to make sure they 
 
     <!-- Spring Controller -->
     <Detector class="com.h3xstream.findsecbugs.endpoint.SpringMvcEndpointDetector">
-        <Details>Identify Spring Endpoint (also called Controller)</Details>
+        <Details>Identifies Spring Endpoint (also called Controller)</Details>
     </Detector>
     <BugPattern type="SPRING_ENDPOINT">
-        <ShortDescription>Found Spring Endpoint</ShortDescription>
-        <LongDescription>{0} is a Spring Controller</LongDescription>
+        <ShortDescription>Found Spring endpoint</ShortDescription>
+        <LongDescription>{0} is a Spring endpoint (Controller)</LongDescription>
         <Details>
             <![CDATA[
 <p>This class is a Spring Controller. All methods annotated with <code>RequestMapping</code> are reachable remotely.
@@ -1060,8 +1060,8 @@ This class should be analyzed to make sure that remotely exposed methods are saf
     </Detector>
 
     <BugPattern type="CUSTOM_INJECTION">
-        <ShortDescription>Potential Injection</ShortDescription>
-        <LongDescription>The use of the method {3} is potentially vulnerable to injection.</LongDescription>
+        <ShortDescription>Potential injection (custom)</ShortDescription>
+        <LongDescription>This use of {3} can be vulnerable to injection</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -1110,7 +1110,7 @@ The method identified is susceptible to injection. The input should be validated
     <!-- HQL Injection -->
     <BugPattern type="SQL_INJECTION_HIBERNATE">
         <ShortDescription>Potential SQL/HQL Injection (Hibernate)</ShortDescription>
-        <LongDescription>The query is potentially vulnerable SQL/HQL injection</LongDescription>
+        <LongDescription>This use of {3} can be vulnerable to SQL/HQL injection</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -1164,7 +1164,7 @@ q.execute();</pre>
     <!-- JDOQL Injection -->
     <BugPattern type="SQL_INJECTION_JDO">
         <ShortDescription>Potential SQL/JDOQL Injection (JDO)</ShortDescription>
-        <LongDescription>The query is potentially vulnerable to SQL/JDOQL injection</LongDescription>
+        <LongDescription>This use of {3} can be vulnerable to SQL/JDOQL injection</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -1208,7 +1208,7 @@ q.execute(input);</pre>
     <!-- JPQL Injection -->
     <BugPattern type="SQL_INJECTION_JPA">
         <ShortDescription>Potential SQL/JPQL Injection (JPA)</ShortDescription>
-        <LongDescription>The query is potentially vulnerable SQL/JPQL injection</LongDescription>
+        <LongDescription>This use of {3} can be vulnerable to SQL/JPQL injection</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -1256,7 +1256,7 @@ UserEntity res = q.getSingleResult();</pre>
     <!-- SPRING JDBC Injection -->
     <BugPattern type="SQL_INJECTION_SPRING_JDBC">
         <ShortDescription>Potential JDBC Injection (Spring JDBC)</ShortDescription>
-        <LongDescription>The query is potentially vulnerable SQL injection</LongDescription>
+        <LongDescription>This use of {3} can be vulnerable to SQL injection</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -1295,7 +1295,7 @@ int count = jdbc.queryForObject("select count(*) from Users where name = ?", Int
     <!-- JDBC Injection -->
     <BugPattern type="SQL_INJECTION_JDBC">
         <ShortDescription>Potential JDBC Injection</ShortDescription>
-        <LongDescription>The query is potentially vulnerable SQL injection</LongDescription>
+        <LongDescription>This use of {3} can be vulnerable to SQL injection</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -1340,7 +1340,7 @@ updateSales.setString(2, coffeeName);</pre>
 
     <BugPattern type="LDAP_INJECTION">
         <ShortDescription>Potential LDAP Injection</ShortDescription>
-        <LongDescription>The query could be vulnerable to LDAP injection</LongDescription>
+        <LongDescription>This use of {3} can be vulnerable to LDAP injection</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -1373,7 +1373,7 @@ Therefore, the primary defense against LDAP injection is strong input validation
 
     <BugPattern type="SCRIPT_ENGINE_INJECTION">
         <ShortDescription>Potential code injection when using Script Engine</ShortDescription>
-        <LongDescription>This code evaluation could be vulnerable to code injection</LongDescription>
+        <LongDescription>This use of {3} can be vulnerable to code injection</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -1436,7 +1436,7 @@ public void runCustomTrigger(String script) {
 
     <BugPattern type="SPEL_INJECTION">
         <ShortDescription>Potential code injection when using Spring Expression</ShortDescription>
-        <LongDescription>This code evaluation could be vulnerable to code injection</LongDescription>
+        <LongDescription>This use of {3} could be vulnerable to code injection</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -1480,7 +1480,7 @@ public void parseExpressionInterface(Person personObj,String property) {
 
     <BugPattern type="HTTP_RESPONSE_SPLITTING">
         <ShortDescription>Potential HTTP Response Splitting</ShortDescription>
-        <LongDescription>{3} is used to possibly include CRLF characters into HTTP headers</LongDescription>
+        <LongDescription>This use of {3} might be used to include CRLF characters into HTTP headers</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -1517,7 +1517,7 @@ response.addCookie(cookie);</pre>
     </Detector>
     <BugPattern type="BAD_HEXA_CONVERSION">
         <ShortDescription>Bad hexadecimal concatenation</ShortDescription>
-        <LongDescription>Leading zero are omit in the concatenation increasing collision potential.</LongDescription>
+        <LongDescription>Leading zeros are omitted in the concatenation increasing collision potential</LongDescription>
         <Details>
             <![CDATA[
 <p>When converting a byte array containing a hash signature to a human readable string, a conversion mistake can be made if 
@@ -1560,7 +1560,7 @@ stringBuilder.append( String.format( "%02X", b ) );</pre>
         <Details>Hazelcast Symmetric Encryption Unsafe</Details>
     </Detector>
     <BugPattern type="HAZELCAST_SYMMETRIC_ENCRYPTION">
-        <ShortDescription>Hazelcast Symmetric Encryption</ShortDescription>
+        <ShortDescription>Hazelcast symmetric encryption</ShortDescription>
         <LongDescription>The network communication for Hazelcast are configured to use a symmetric cipher</LongDescription>
         <Details>
             <![CDATA[
@@ -1584,7 +1584,7 @@ stringBuilder.append( String.format( "%02X", b ) );</pre>
         <Details>Identify the use of NullCipher</Details>
     </Detector>
     <BugPattern type="NULL_CIPHER">
-        <ShortDescription>NullCipher Unsafe</ShortDescription>
+        <ShortDescription>NullCipher is insecure</ShortDescription>
         <LongDescription>The use of a NullCipher is typically not desirable</LongDescription>
         <Details>
             <![CDATA[
@@ -1660,8 +1660,8 @@ to do this correctly.
         <Details>DES / DESede should be replace by AES</Details>
     </Detector>
     <BugPattern type="DES_USAGE">
-        <ShortDescription>DES / DESede Unsafe</ShortDescription>
-        <LongDescription>DES / DESede should be replaced with AES</LongDescription>
+        <ShortDescription>DES/DESede is insecure</ShortDescription>
+        <LongDescription>DES/DESede should be replaced with AES</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -1697,7 +1697,7 @@ byte[] cipherText = c.doFinal(plainText);</pre>
         <Details>RSA cipher without proper padding</Details>
     </Detector>
     <BugPattern type="RSA_NO_PADDING">
-        <ShortDescription>RSA NoPadding Unsafe</ShortDescription>
+        <ShortDescription>RSA with no padding is insecure</ShortDescription>
         <LongDescription>Use of RSA cipher without proper padding</LongDescription>
         <Details>
             <![CDATA[
@@ -1802,7 +1802,7 @@ return aesCipher.doFinal(secretData);</pre>
         <Details>Identify Struts Form with no input validation</Details>
     </Detector>
     <BugPattern type="STRUTS_FORM_VALIDATION">
-        <ShortDescription>Struts Form Without Input Validation</ShortDescription>
+        <ShortDescription>Struts Form without input validation</ShortDescription>
         <LongDescription>Struts Form with no input validation</LongDescription>
         <Details>
             <![CDATA[
@@ -1842,7 +1842,7 @@ public class RegistrationForm extends ValidatorForm {
         <Details>Identify XSSRequestWrapper (weak XSS protection)</Details>
     </Detector>
     <BugPattern type="XSS_REQUEST_WRAPPER">
-        <ShortDescription>XSSRequestWrapper is Weak XSS Protection</ShortDescription>
+        <ShortDescription>XSSRequestWrapper is a weak XSS protection</ShortDescription>
         <LongDescription>XSSRequestWrapper is a weak XSS protection mechanism</LongDescription>
         <Details>
             <![CDATA[
@@ -1890,8 +1890,8 @@ the XSS protection rules defined in the OWASP XSS Prevention Cheat Sheet.
         <Details>Identify Blowfish usage with weak key size</Details>
     </Detector>
     <BugPattern type="BLOWFISH_KEY_SIZE">
-        <ShortDescription>Blowfish Usage with Weak Key Size</ShortDescription>
-        <LongDescription>Blowfish usage with weak key size</LongDescription>
+        <ShortDescription>Blowfish usage with short key</ShortDescription>
+        <LongDescription>Blowfish usage with a short encryption key</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -1928,8 +1928,8 @@ keyGen.init(128);</pre>
         <Details>Identify RSA usage with weak key size</Details>
     </Detector>
     <BugPattern type="RSA_KEY_SIZE">
-        <ShortDescription>RSA Usage with Weak Key Size</ShortDescription>
-        <LongDescription>RSA usage with weak key size</LongDescription>
+        <ShortDescription>RSA usage with short key</ShortDescription>
+        <LongDescription>RSA usage with a short key</LongDescription>
         <Details>
             <![CDATA[
 <p>"RSA Laboratories currently recommends key sizes of 1024 bits for corporate use and 2048 bits for extremely valuable keys 
@@ -1968,7 +1968,7 @@ keyGen.initialize(2048);
     </Detector>
     <BugPattern type="UNVALIDATED_REDIRECT">
         <ShortDescription>Unvalidated Redirect</ShortDescription>
-        <LongDescription>Unvalidated Redirect</LongDescription>
+        <LongDescription>This use of {3} can be vulnerable to sending unvalidated redirects</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -2038,7 +2038,7 @@ TODO
     </Detector>
     <BugPattern type="JSP_SPRING_EVAL">
         <ShortDescription>Dynamic variable in spring expression</ShortDescription>
-        <LongDescription>Potential unintended use of dynamic variable in spring expression could lead to arbitrary code execution</LongDescription>
+        <LongDescription>Dynamic variable in spring expression could lead to arbitrary code execution</LongDescription>
         <Details>
             <![CDATA[
 TODO
@@ -2053,7 +2053,7 @@ TODO
         <Details>Detect output where the escaping of special XML characters is disable.</Details>
     </Detector>
     <BugPattern type="JSP_JSTL_OUT">
-        <ShortDescription>Escaping of special XML characters is disable</ShortDescription>
+        <ShortDescription>Escaping of special XML characters is disabled</ShortDescription>
         <LongDescription>Disabling the escaping of special XML characters can lead to XSS vulnerabilities</LongDescription>
         <Details>
             <![CDATA[
@@ -2275,8 +2275,8 @@ public void encrypt(String message) throws Exception {
 
     <!-- ECB Mode -->
     <BugPattern type="ECB_MODE">
-        <ShortDescription>ECB Mode Unsafe</ShortDescription>
-        <LongDescription>The cipher chosen uses ECB mode, which provides poor confidentiality for encrypted data.</LongDescription>
+        <ShortDescription>ECB mode is insecure</ShortDescription>
+        <LongDescription>The cipher uses ECB mode, which provides poor confidentiality for encrypted data</LongDescription>
         <Details>
             <![CDATA[
 <p>An authentication cipher mode which provides better confidentiality of the encrypted data should be used instead of Electronic Codebook (ECB) mode, 
@@ -2314,7 +2314,7 @@ byte[] cipherText = c.doFinal(plainText);</pre>
 
     <!-- Padding oracle -->
     <BugPattern type="PADDING_ORACLE">
-        <ShortDescription>Cipher is Susceptible to Padding Oracle</ShortDescription>
+        <ShortDescription>Cipher is susceptible to Padding Oracle</ShortDescription>
         <LongDescription>The cipher is susceptible to padding oracle attacks</LongDescription>
         <Details>
 <![CDATA[
@@ -2352,8 +2352,8 @@ byte[] cipherText = c.doFinal(plainText);</pre>
 
     <!-- Integrity missing -->
     <BugPattern type="CIPHER_INTEGRITY">
-        <ShortDescription>Cipher With No Integrity</ShortDescription>
-        <LongDescription>The cipher used does not provide an data integrity</LongDescription>
+        <ShortDescription>Cipher with no integrity</ShortDescription>
+        <LongDescription>The cipher does not provide data integrity</LongDescription>
         <Details>
 <![CDATA[
 <p>
@@ -2408,7 +2408,7 @@ In the example solution above, the GCM mode introduces an HMAC into the resultin
         <Details>Identity usage of ESAPI Encryptor.</Details>
     </Detector>
     <BugPattern type="ESAPI_ENCRYPTOR">
-        <ShortDescription>Usage of ESAPI Encryptor</ShortDescription>
+        <ShortDescription>Use of ESAPI Encryptor</ShortDescription>
         <LongDescription>The ESAPI encryptor API is used to encrypt data</LongDescription>
         <Details>
 <![CDATA[
@@ -2495,8 +2495,8 @@ Encryptor.cipher_modes.additional_allowed=</pre>
         <Details>Identity file access on external storage.</Details>
     </Detector>
     <BugPattern type="ANDROID_EXTERNAL_FILE_ACCESS">
-        <ShortDescription>External File Access (Android)</ShortDescription>
-        <LongDescription>Files could be saved to external storage.</LongDescription>
+        <ShortDescription>External file access (Android)</ShortDescription>
+        <LongDescription>Files could be saved to external storage</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -2543,7 +2543,7 @@ fos.write(string.getBytes());
     </Detector>
     <BugPattern type="ANDROID_BROADCAST">
         <ShortDescription>Broadcast (Android)</ShortDescription>
-        <LongDescription>Broadcast intents could be received by a malicious application.</LongDescription>
+        <LongDescription>Broadcast intents could be received by a malicious application</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -2623,8 +2623,8 @@ sendBroadcast(v1);
         <Details>Identity file written with the creation mode MODE_WORLD_READABLE.</Details>
     </Detector>
     <BugPattern type="ANDROID_WORLD_WRITABLE">
-        <ShortDescription>World Writable File (Android)</ShortDescription>
-        <LongDescription>The content that is written can be viewed by any application.</LongDescription>
+        <ShortDescription>World writable file (Android)</ShortDescription>
+        <LongDescription>The content that is written can be viewed by any application</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -2672,8 +2672,8 @@ create on external storage. See references below for implementation guidelines.
         <Details>Identity usage of Geolocation API.</Details>
     </Detector>
     <BugPattern type="ANDROID_GEOLOCATION">
-        <ShortDescription>WebView with Geolocation Activated (Android)</ShortDescription>
-        <LongDescription>WebView with Geolocation Activated</LongDescription>
+        <ShortDescription>WebView with geolocation activated (Android)</ShortDescription>
+        <LongDescription>WebView with activated geolocation</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -2723,8 +2723,8 @@ webView.setWebChromeClient(new WebChromeClient() {
         <Details>Identity WebView with JavaScript Enabled.</Details>
     </Detector>
     <BugPattern type="ANDROID_WEB_VIEW_JAVASCRIPT">
-        <ShortDescription>WebView with JavaScript Enabled (Android)</ShortDescription>
-        <LongDescription>WebView with JavaScript Enabled</LongDescription>
+        <ShortDescription>WebView with JavaScript enabled (Android)</ShortDescription>
+        <LongDescription>WebView with JavaScript enabled</LongDescription>
         <Details>
             <![CDATA[
 <p>
@@ -2765,15 +2765,15 @@ function updateDescription(newDescription) {
 
     <!-- Android:  -->
     <Detector class="com.h3xstream.findsecbugs.android.WebViewJavascriptInterfaceDetector">
-        <Details>Identity WebView with a Java bridge (Javascript Interface).</Details>
+        <Details>Identity WebView with a Java bridge (JavaScript Interface).</Details>
     </Detector>
     <BugPattern type="ANDROID_WEB_VIEW_JAVASCRIPT_INTERFACE">
-        <ShortDescription>WebView with Javascript Interface (Android)</ShortDescription>
-        <LongDescription>WebView with Javascript Interface (Android)</LongDescription>
+        <ShortDescription>WebView with JavaScript interface (Android)</ShortDescription>
+        <LongDescription>WebView with JavaScript interface</LongDescription>
         <Details>
             <![CDATA[
 <p>
-    The use Javascript Interface could expose the WebView to risky API. If an XSS is trigger in the WebView, the class
+    The use JavaScript Interface could expose the WebView to risky API. If an XSS is trigger in the WebView, the class
     could be call by the malicious JavaScript code.
 </p>
 
@@ -2819,7 +2819,7 @@ class FileWriteUtil {
 
     <BugPattern type="INSECURE_COOKIE">
         <ShortDescription>Cookie without the secure flag</ShortDescription>
-        <LongDescription>Cookie without the secure flag could be sent in cleartext if a HTTP URL is visited.</LongDescription>
+        <LongDescription>Cookie without the secure flag could be sent in clear text if a HTTP URL is visited</LongDescription>
         <Details>
             <![CDATA[
 <p>

--- a/plugin/src/main/resources/taint-config/methods-summaries.txt
+++ b/plugin/src/main/resources/taint-config/methods-summaries.txt
@@ -258,6 +258,13 @@ java/net/URL.toString()Ljava/lang/String;:0
 java/net/URL.toURI()Ljava/net/URI;:0
 
 
+java/net/URLEncoder.encode(Ljava/lang/String;)Ljava/lang/String;:0
+java/net/URLEncoder.encode(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;:1
+
+java/net/URLDecoder.decode(Ljava/lang/String;)Ljava/lang/String;:0
+java/net/URLDecoder.decode(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;:1
+
+
 - Objects from Java 8 function package are UNKNOWN by default, some could be made SAFE or TAINTED in the future
 java/langIterable.forEach(Ljava/util/function/Consumer;)V:0,1#1
 java/lang/Iterable.iterator()Ljava/util/Iterator;:0

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/HttpResponseSplittingDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/HttpResponseSplittingDetectorTest.java
@@ -1,0 +1,48 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import java.util.Arrays;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import org.testng.annotations.Test;
+
+public class HttpResponseSplittingDetectorTest extends BaseDetectorTest {
+    
+    @Test
+    public void detectResponseSplitting() throws Exception {
+        String[] files = {
+                getClassFilePath("testcode/ResponseSplittingServlet")
+        };
+        EasyBugReporter reporter = spy(new EasyBugReporter());
+        analyze(files, reporter);
+
+        for (Integer line : Arrays.asList(12, 13, 14, 15)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("HTTP_RESPONSE_SPLITTING")
+                            .inClass("ResponseSplittingServlet").inMethod("doGet").atLine(line)
+                            .build()
+            );
+        }
+        verify(reporter, times(4)).doReportBug(bugDefinition().bugType("HTTP_RESPONSE_SPLITTING").build());
+    }
+}

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/WeakMessageDigestDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/WeakMessageDigestDetectorTest.java
@@ -69,7 +69,7 @@ public class WeakMessageDigestDetectorTest extends BaseDetectorTest {
 
         //Message Digest
         int l = 37;
-        for(int line : Arrays.asList(l++,l++,l++,l++, l+=2,l++,l++, l+=2,l++,l++)) {
+        for(int line : Arrays.asList(l++,l++,l++,l++, l+=2,l++,l++, l+=2,l++,l++,l++,l++,l++)) {
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("WEAK_MESSAGE_DIGEST")
@@ -78,7 +78,7 @@ public class WeakMessageDigestDetectorTest extends BaseDetectorTest {
             );
         }
 
-        verify(reporter,times(10)).doReportBug(
+        verify(reporter,times(15)).doReportBug(
                 bugDefinition()
                         .bugType("WEAK_MESSAGE_DIGEST")
                         .inClass("WeakMessageDigest").inMethod("apacheApiVariations")

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/WeakMessageDigestDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/WeakMessageDigestDetectorTest.java
@@ -98,7 +98,7 @@ public class WeakMessageDigestDetectorTest extends BaseDetectorTest {
         analyze(files, reporter);
 
         //Message Digest
-        for(int line : Arrays.asList(11,12,13,14,15,16,17,18,19,20,21)) {
+        for(int line : Arrays.asList(12,13,14,15,16,17,18,19,20,21, 22, 26, 27, 28)) {
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("WEAK_MESSAGE_DIGEST")
@@ -107,7 +107,7 @@ public class WeakMessageDigestDetectorTest extends BaseDetectorTest {
             );
         }
 
-        verify(reporter,times(11)).doReportBug(
+        verify(reporter,times(14)).doReportBug(
                 bugDefinition()
                         .bugType("WEAK_MESSAGE_DIGEST")
                         .inClass("WeakMessageDigestAdditionalSig").inMethod("weakDigestMoreSig")

--- a/plugin/src/test/java/testcode/ResponseSplittingServlet.java
+++ b/plugin/src/test/java/testcode/ResponseSplittingServlet.java
@@ -1,0 +1,24 @@
+package testcode;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class ResponseSplittingServlet extends HttpServlet {
+    
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+        Cookie cookie = new Cookie("name", req.getParameter("v"));
+        cookie.setValue(req.getParameter("p") + "x");
+        resp.setHeader("header", req.getParameter("h1"));
+        resp.addHeader("header", req.getParameter("h2"));
+        
+        // false positives
+        String safe = "x".concat("y");
+        Cookie safeCookie = new Cookie("name", safe);
+        safeCookie.setValue(safe + "x");
+        resp.setHeader("header", safe);
+        resp.addHeader("header", safe);
+    }
+}

--- a/plugin/src/test/java/testcode/crypto/WeakMessageDigest.java
+++ b/plugin/src/test/java/testcode/crypto/WeakMessageDigest.java
@@ -46,6 +46,11 @@ public class WeakMessageDigest {
         System.out.println(DigestUtils.md2Hex("123".getBytes()));
         System.out.println(DigestUtils.md5Hex("123".getBytes()));
         System.out.println(DigestUtils.sha1Hex("123".getBytes()));
+        DigestUtils.md2("123".getBytes());
+        DigestUtils.md5("123".getBytes());
+        DigestUtils.sha1("123".getBytes());
+        DigestUtils.sha("123".getBytes());
+        DigestUtils.shaHex("123".getBytes());
 
         printHex(DigestUtils.getDigest("sha256").digest("123".getBytes())); //OK!
         printHex(DigestUtils.getDigest(getDigest()).digest("123".getBytes())); //Unknown

--- a/plugin/src/test/java/testcode/crypto/WeakMessageDigestAdditionalSig.java
+++ b/plugin/src/test/java/testcode/crypto/WeakMessageDigestAdditionalSig.java
@@ -4,6 +4,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.Provider;
+import java.security.Signature;
 
 public class WeakMessageDigestAdditionalSig {
 
@@ -21,6 +22,12 @@ public class WeakMessageDigestAdditionalSig {
         MessageDigest.getInstance("MD2", new DummyProvider());
         MessageDigest.getInstance("sha-384","SUN"); //OK!
         MessageDigest.getInstance("SHA-512", "SUN"); //OK!
+        
+        Signature.getInstance("MD5withRSA");
+        Signature.getInstance("SHA1withRSA", new DummyProvider());
+        Signature.getInstance("MD2withDSA", "X");
+        Signature.getInstance("SHA256withRSA"); //OK
+        Signature.getInstance("uncommon name", ""); //OK
     }
 
     static class DummyProvider extends Provider {


### PR DESCRIPTION
Fixes #121 and fixes #120. In addition, I have modified many reported messages - injectable arguments are shown for every injection and messages should be more unified (capital letters, periods etc.), please check if there is something you don't like. 